### PR TITLE
Remove requirement for password, works without as well

### DIFF
--- a/dbeam/src/main/scala/com/spotify/dbeam/SqlAvroOptions.scala
+++ b/dbeam/src/main/scala/com/spotify/dbeam/SqlAvroOptions.scala
@@ -133,6 +133,10 @@ object SqlAvroOptions {
       .map(Source.fromFile(_).mkString.stripLineEnd)
       .orElse(args.optional("password"))
 
+    require(sqlReadOptions.getConnectionUrl != null, "'connectionUrl' must be defined")
+    require(sqlReadOptions.getOutput != null, "'output' must be defined")
+    require(sqlReadOptions.getTable != null, "'table' must be defined")
+
     if (!skipPartitionCheck && partitionColumn.isEmpty) {
       val minPartitionDateTime = args.optional("minPartitionPeriod")
         .map(parseDateTime)

--- a/dbeam/src/main/scala/com/spotify/dbeam/SqlAvroOptions.scala
+++ b/dbeam/src/main/scala/com/spotify/dbeam/SqlAvroOptions.scala
@@ -133,9 +133,6 @@ object SqlAvroOptions {
       .map(Source.fromFile(_).mkString.stripLineEnd)
       .orElse(args.optional("password"))
 
-    require(password.isDefined,
-      "password must be configured either through --password or --passwordFile parameter")
-
     if (!skipPartitionCheck && partitionColumn.isEmpty) {
       val minPartitionDateTime = args.optional("minPartitionPeriod")
         .map(parseDateTime)

--- a/dbeam/src/test/scala/com/spotify/dbeam/SqlAvroOptionsTest.scala
+++ b/dbeam/src/test/scala/com/spotify/dbeam/SqlAvroOptionsTest.scala
@@ -52,11 +52,22 @@ class SqlAvroOptionsTest extends FlatSpec with Matchers {
       optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table")
     }
   }
-  it should "fail to parse with missing password parameter" in {
-    a[IllegalArgumentException] should be thrownBy {
-      optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
-        "--output=/path")
-    }
+  it should "parse correctly with missing password parameter" in {
+    val options = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
+      "--output=/path")
+
+    options should be (SqlAvroOptions(
+      "org.postgresql.Driver",
+      "jdbc:postgresql://nonsense",
+      "dbeam-extractor",
+      null,
+      "some_table",
+      "/path",
+      "dbeam_generated",
+      None,
+      None,
+      None
+    ))
   }
   it should "fail to parse invalid table parameter" in {
     a[IllegalArgumentException] should be thrownBy {


### PR DESCRIPTION
`--password` parameter might not be necessary when running locally.