### PR TITLE
Refactors: remove output from JdbcExportArgs

### DIFF
--- a/dbeam/src/main/scala/com/spotify/dbeam/JdbcAvroJob.scala
+++ b/dbeam/src/main/scala/com/spotify/dbeam/JdbcAvroJob.scala
@@ -58,7 +58,6 @@ object JdbcAvroJob {
         ScioMetrics.counter("schemaElapsedTimeMs").inc(elapsedTimeSchema)
         inp
       })
-    saveString(args.pathInOutput("/_AVRO_SCHEMA.avsc"), generatedSchema.toString(true))
     generatedSchema
   }
 
@@ -86,13 +85,13 @@ object JdbcAvroJob {
     )
   }
 
-  def publishMetrics(scioResult: ScioResult, args: JdbcExportArgs): Unit = {
+  def publishMetrics(scioResult: ScioResult, outputUri: String): Unit = {
     log.info(s"Metrics ${scioResult.getMetrics.toString}")
     val metrics: Map[MetricName, MetricValue[_]] = scioResult.allCounters ++ scioResult.allGauges
     log.info(s"all counters and gauges ${metrics.toString}")
 
-    saveJsonObject(args.pathInOutput("/_METRICS.json"), metrics)
-    scioResult.saveMetrics(args.pathInOutput("/_SERVICE_METRICS.json"))
+    saveJsonObject(subPath(outputUri, "/_METRICS.json"), metrics)
+    scioResult.saveMetrics(subPath(outputUri, "/_SERVICE_METRICS.json"))
   }
 
   private def writeToFile(filename: String, contents: ByteBuffer): Unit = {
@@ -116,23 +115,33 @@ object JdbcAvroJob {
     writeToFile(filename, ByteBuffer.wrap(contents.getBytes(Charset.defaultCharset())))
   }
 
-  def runExport(sc: ScioContext, args: JdbcExportArgs): Unit = {
-    val generatedSchema: Schema = createSchema(sc, args)
+  private def subPath(path: String, subPath: String): String =
+    path.replaceAll("/+$", "") + subPath
 
-    val queries = args.buildQueries()
+  def runExport(sc: ScioContext, args: JdbcExportArgs, outputUri: String): Unit = {
+    require(outputUri != null && outputUri != "", "'output' must be defined")
+    val generatedSchema: Schema = createSchema(sc, args)
+    saveString(subPath(outputUri, "/_AVRO_SCHEMA.avsc"), generatedSchema.toString(true))
+
+    val queries: Iterable[String] = args.buildQueries()
+    queries.zipWithIndex.foreach{ case (q: String, n: Int) =>
+      saveString(subPath(outputUri, s"/_queries/query_${n}.sql"), q)
+    }
     log.info(s"Running queries: $queries")
 
-    val querySCollection = sc.parallelize(queries)
-    querySCollection.withName("SaveQueries").saveAsTextFile(args.pathInOutput("/_queries"), ".sql")
-    querySCollection.internal.apply("JdbcAvroSave",
-      jdbcAvroTransform(args.output, args, generatedSchema))
+    sc
+      .parallelize(queries)
+      .internal
+      .apply("JdbcAvroSave",
+        jdbcAvroTransform(outputUri, args, generatedSchema))
 
     val scioResult: ScioResult = sc.close().waitUntilDone()
-    publishMetrics(scioResult, args)
+    publishMetrics(scioResult, outputUri)
   }
 
   def main(cmdlineArgs: Array[String]): Unit = {
-    val (sc: ScioContext, args: JdbcExportArgs) = JdbcExportArgs.contextAndArgs(cmdlineArgs)
-    runExport(sc, args)
+    val (sc: ScioContext, jdbcExportArgs: JdbcExportArgs, outputUri: String) =
+      JdbcExportArgs.contextAndArgs(cmdlineArgs)
+    runExport(sc, jdbcExportArgs, outputUri)
   }
 }

--- a/dbeam/src/main/scala/com/spotify/dbeam/PsqlAvroJob.scala
+++ b/dbeam/src/main/scala/com/spotify/dbeam/PsqlAvroJob.scala
@@ -88,13 +88,13 @@ object PsqlAvroJob {
   }
 
   def main(cmdlineArgs: Array[String]): Unit = {
-    val (sc: ScioContext, jdbcExportArgs: JdbcExportArgs, outputUri: String) =
+    val (sc: ScioContext, jdbcExportArgs: JdbcExportArgs, output: String) =
       JdbcExportArgs.contextAndArgs(cmdlineArgs)
 
     if (isReplicationDelayed(jdbcExportArgs)) {
       System.exit(20)
     } else {
-      JdbcAvroJob.runExport(sc, jdbcExportArgs, outputUri)
+      JdbcAvroJob.runExport(sc, jdbcExportArgs, output)
     }
   }
 

--- a/dbeam/src/main/scala/com/spotify/dbeam/PsqlAvroJob.scala
+++ b/dbeam/src/main/scala/com/spotify/dbeam/PsqlAvroJob.scala
@@ -78,20 +78,24 @@ object PsqlAvroJob {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
-  def main(cmdlineArgs: Array[String]): Unit = {
-    val (sc: ScioContext, jdbcExportArgs: JdbcExportArgs) =
-      JdbcExportArgs.contextAndArgs(cmdlineArgs)
+  def isReplicationDelayed(jdbcExportArgs: JdbcExportArgs): Boolean = {
     validateOptions(jdbcExportArgs)
-
     val partition: DateTime = jdbcExportArgs.partition.get
     val partitionPeriod: ReadablePeriod = jdbcExportArgs.partitionPeriod
     val lastReplication = queryReplication(jdbcExportArgs.createConnection())
 
-    if (isReplicationDelayed(partition, lastReplication, partitionPeriod)) {
-      System.exit(20)
-    }
+    isReplicationDelayed(partition, lastReplication, partitionPeriod)
+  }
 
-    JdbcAvroJob.runExport(sc, jdbcExportArgs)
+  def main(cmdlineArgs: Array[String]): Unit = {
+    val (sc: ScioContext, jdbcExportArgs: JdbcExportArgs, outputUri: String) =
+      JdbcExportArgs.contextAndArgs(cmdlineArgs)
+
+    if (isReplicationDelayed(jdbcExportArgs)) {
+      System.exit(20)
+    } else {
+      JdbcAvroJob.runExport(sc, jdbcExportArgs, outputUri)
+    }
   }
 
 }

--- a/dbeam/src/main/scala/com/spotify/dbeam/options/DBeamPipelineOptions.scala
+++ b/dbeam/src/main/scala/com/spotify/dbeam/options/DBeamPipelineOptions.scala
@@ -54,12 +54,6 @@ trait DBeamPipelineOptions extends PipelineOptions {
 
 @Description("Configure dbeam SQL export")
 trait JdbcExportPipelineOptions extends DBeamPipelineOptions {
-  @Description("The path for storing the output.")
-  @Required
-  def getOutput: String
-
-  def setOutput(value: String): Unit
-
   @Description("The date of the current partition.")
   def getPartition: String
 
@@ -102,6 +96,14 @@ trait JdbcExportPipelineOptions extends DBeamPipelineOptions {
   def getAvroDoc: String
 
   def setAvroDoc(value: String): Unit
+}
+
+trait OutputOptions extends PipelineOptions {
+  @Description("The path for storing the output.")
+  @Required
+  def getOutput: String
+
+  def setOutput(value: String): Unit
 }
 
 object PipelineOptionsUtil {

--- a/dbeam/src/test/scala/com/spotify/dbeam/JdbcAvroJobTest.scala
+++ b/dbeam/src/test/scala/com/spotify/dbeam/JdbcAvroJobTest.scala
@@ -56,11 +56,14 @@ class JdbcAvroJobTest extends PipelineSpec with Matchers with BeforeAndAfterAll 
         "--password=",
         "--table=coffees",
         "--output=" + dir.getAbsolutePath)
-        .output[String](TextIO(dir.getAbsolutePath + "/_queries"))(_ should haveSize(1))
+//        .output[String](TextIO(dir.getAbsolutePath + "/_queries"))(_ should haveSize(1))
       .run()
     val files: Array[File] = dir.listFiles()
     files.map(_.getName) should contain theSameElementsAs (Seq(
-      "_AVRO_SCHEMA.avsc", "_METRICS.json", "_SERVICE_METRICS.json", "part-00000-of-00001.avro"))
+      "_AVRO_SCHEMA.avsc", "_METRICS.json", "_SERVICE_METRICS.json",
+      "_queries", "part-00000-of-00001.avro"))
+    files.filter(_.getName.equals("_queries"))(0).listFiles().map(_.getName) should
+      contain theSameElementsAs (Seq("query_0.sql"))
     val schema = (new Schema.Parser()).parse(new File(dir, "_AVRO_SCHEMA.avsc"))
     val source: AvroSource[GenericRecord] = AvroSource
       .from(new File(dir, "part-00000-of-00001.avro").toString)

--- a/dbeam/src/test/scala/com/spotify/dbeam/PsqlAvroJobTest.scala
+++ b/dbeam/src/test/scala/com/spotify/dbeam/PsqlAvroJobTest.scala
@@ -42,7 +42,6 @@ class PsqlAvroJobTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       "dbeam-extractor",
       "secret",
       "some_table",
-      "/path",
       "dbeam_generated"
     )
 
@@ -58,7 +57,6 @@ class PsqlAvroJobTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       "dbeam-extractor",
       "secret",
       "some_table",
-      "/path",
       "dbeam_generated"
     )
 
@@ -74,7 +72,6 @@ class PsqlAvroJobTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       "dbeam-extractor",
       "secret",
       "some_table",
-      "/path",
       "dbeam_generated",
       partition = Some(new DateTime(2027, 7, 31, 0, 0, DateTimeZone.UTC))
     )

--- a/dbeam/src/test/scala/com/spotify/dbeam/options/JdbcExportArgsTest.scala
+++ b/dbeam/src/test/scala/com/spotify/dbeam/options/JdbcExportArgsTest.scala
@@ -39,22 +39,16 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
   }
   it should "fail to parse with missing connectionUrl parameter" in {
     a[IllegalArgumentException] should be thrownBy {
-      optionsFromArgs("--table=some-table --output=/path")
+      optionsFromArgs("--table=some-table")
     }
   }
   it should "fail to parse with missing table parameter" in {
     a[IllegalArgumentException] should be thrownBy {
-      optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --output=/path")
-    }
-  }
-  it should "fail to parse with missing output parameter" in {
-    a[IllegalArgumentException] should be thrownBy {
-      optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table")
+      optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense")
     }
   }
   it should "parse correctly with missing password parameter" in {
-    val options = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
-      "--output=/path")
+    val options = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table")
 
     options should be (JdbcExportArgs(
       "org.postgresql.Driver",
@@ -62,7 +56,6 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam-extractor",
       null,
       "some_table",
-      "/path",
       "dbeam_generated",
       None,
       None,
@@ -72,47 +65,47 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
   it should "fail to parse invalid table parameter" in {
     a[IllegalArgumentException] should be thrownBy {
       optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some-table " +
-        "--output=/path --password=secret")
+        "--password=secret")
     }
   }
   it should "fail to parse non jdbc connection parameter" in {
     a[IllegalArgumentException] should be thrownBy {
-      optionsFromArgs("--connectionUrl=bar --table=some_table --output=/path --password=secret")
+      optionsFromArgs("--connectionUrl=bar --table=some_table --password=secret")
     }
   }
   it should "fail to parse unsupported jdbc connection parameter" in {
     a[IllegalArgumentException] should be thrownBy {
       optionsFromArgs("--connectionUrl=jdbc:paradox:./foo --table=some_table " +
-        "--output=/path --password=secret")
+        "--password=secret")
     }
   }
   it should "fail to parse missing partition parameter but partition column present" in {
     a[IllegalArgumentException] should be thrownBy {
       optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
-        "--output=/path --password=secret --partitionColumn=col")
+        "--password=secret --partitionColumn=col")
     }
   }
   it should "fail on too old partition parameter" in {
     a[IllegalArgumentException] should be thrownBy {
       optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
-        "--output=/path --password=secret --partition=2015-01-01")
+        "--password=secret --partition=2015-01-01")
     }
   }
   it should "fail on old partition parameter with configured partition = min-partition-period" in {
     a[IllegalArgumentException] should be thrownBy {
       optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
-        "--output=/path --password=secret --partition=2015-01-01 --minPartitionPeriod=2015-01-01")
+        "--password=secret --partition=2015-01-01 --minPartitionPeriod=2015-01-01")
     }
   }
   it should "fail on old partition parameter with configured partition < min-partition-period" in {
     a[IllegalArgumentException] should be thrownBy {
       optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
-        "--output=/path --password=secret --partition=2015-01-01 --minPartitionPeriod=2015-01-02")
+        "--password=secret --partition=2015-01-01 --minPartitionPeriod=2015-01-02")
     }
   }
   it should "parse correctly for postgresql connection" in {
     val options = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
-      "--output=/path --password=secret")
+      "--password=secret")
 
     options should be (JdbcExportArgs(
       "org.postgresql.Driver",
@@ -120,7 +113,6 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam-extractor",
       "secret",
       "some_table",
-      "/path",
       "dbeam_generated",
       None,
       None,
@@ -129,7 +121,7 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
   }
   it should "parse correctly for mysql connection" in {
     val options = optionsFromArgs("--connectionUrl=jdbc:mysql://nonsense --table=some_table " +
-      "--output=/path --password=secret")
+      "--password=secret")
 
     options should be (JdbcExportArgs(
       "com.mysql.jdbc.Driver",
@@ -137,7 +129,6 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam-extractor",
       "secret",
       "some_table",
-      "/path",
       "dbeam_generated",
       None,
       None,
@@ -146,7 +137,7 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
   }
   it should "configure username" in {
     val options = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense " +
-      "--table=some_table --output=/path --password=secret --username=some_user")
+      "--table=some_table --password=secret --username=some_user")
 
     options should be (JdbcExportArgs(
       "org.postgresql.Driver",
@@ -154,7 +145,6 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "some_user",
       "secret",
       "some_table",
-      "/path",
       "dbeam_generated",
       None,
       None,
@@ -163,7 +153,7 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
   }
   it should "configure limit" in {
     val actual = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense " +
-      "--table=some_table --output=/path --password=secret --limit=7")
+      "--table=some_table --password=secret --limit=7")
 
     val expected = JdbcExportArgs(
       "org.postgresql.Driver",
@@ -171,7 +161,6 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam-extractor",
       "secret",
       "some_table",
-      "/path",
       "dbeam_generated",
       Some(7),
       None,
@@ -182,7 +171,7 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
   }
   it should "configure partition" in {
     val actual = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense " +
-      "--table=some_table --output=/path --password=secret --partition=2027-07-31")
+      "--table=some_table --password=secret --partition=2027-07-31")
 
     val expected = JdbcExportArgs(
       "org.postgresql.Driver",
@@ -190,7 +179,6 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam-extractor",
       "secret",
       "some_table",
-      "/path",
       "dbeam_generated",
       None,
       None,
@@ -201,7 +189,7 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
   }
   it should "configure partition with full ISO date time (Styx cron syntax)" in {
     val actual = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
-      "--output=/path --password=secret --partition=2027-07-31T13:37:59Z")
+      "--password=secret --partition=2027-07-31T13:37:59Z")
 
     val expected = JdbcExportArgs(
       "org.postgresql.Driver",
@@ -209,7 +197,6 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam-extractor",
       "secret",
       "some_table",
-      "/path",
       "dbeam_generated",
       None,
       None,
@@ -220,7 +207,7 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
   }
   it should "configure partition with month date (Styx monthly schedule)" in {
     val actual = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense " +
-      "--table=some_table --output=/path --password=secret --partition=2027-05")
+      "--table=some_table --password=secret --partition=2027-05")
 
     val expected = JdbcExportArgs(
       "org.postgresql.Driver",
@@ -228,7 +215,6 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam-extractor",
       "secret",
       "some_table",
-      "/path",
       "dbeam_generated",
       None,
       None,
@@ -239,7 +225,7 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
   }
   it should "configure partition column" in {
     val actual = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
-      "--output=/path --password=secret --partition=2027-07-31 --partitionColumn=col")
+      "--password=secret --partition=2027-07-31 --partitionColumn=col")
 
     val expected = JdbcExportArgs(
       "org.postgresql.Driver",
@@ -247,7 +233,6 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam-extractor",
       "secret",
       "some_table",
-      "/path",
       "dbeam_generated",
       None,
       Some("col"),
@@ -259,7 +244,7 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
   }
   it should "configure partition column and limit" in {
     val actual = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
-      "--output=/path --password=secret --partition=2027-07-31 --partitionColumn=col --limit=5")
+      "--password=secret --partition=2027-07-31 --partitionColumn=col --limit=5")
 
     val expected = JdbcExportArgs(
       "org.postgresql.Driver",
@@ -267,7 +252,6 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam-extractor",
       "secret",
       "some_table",
-      "/path",
       "dbeam_generated",
       Some(5),
       Some("col"),
@@ -279,7 +263,7 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
   }
   it should "configure partition column and partition period" in {
     val actual = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
-      "--output=/path --password=secret --partition=2027-07-31 " +
+      "--password=secret --partition=2027-07-31 " +
       "--partitionColumn=col --partitionPeriod=P1M")
 
     val expected = JdbcExportArgs(
@@ -288,7 +272,6 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam-extractor",
       "secret",
       "some_table",
-      "/path",
       "dbeam_generated",
       None,
       Some("col"),
@@ -301,7 +284,7 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
   }
   it should "configure avro schema namespace" in {
     val options = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
-      "--output=/path --password=secret --avroSchemaNamespace=ns")
+      "--password=secret --avroSchemaNamespace=ns")
 
     options should be (JdbcExportArgs(
       "org.postgresql.Driver",
@@ -309,7 +292,6 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam-extractor",
       "secret",
       "some_table",
-      "/path",
       "ns",
       None,
       None,
@@ -318,7 +300,7 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
   }
   it should "configure avro doc" in {
     val options = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
-      "--output=/path --password=secret --avroDoc=doc")
+      "--password=secret --avroDoc=doc")
 
     options should be (JdbcExportArgs(
       "org.postgresql.Driver",
@@ -326,7 +308,6 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam-extractor",
       "secret",
       "some_table",
-      "/path",
       "dbeam_generated",
       avroDoc=Some("doc")
     ))


### PR DESCRIPTION
- Remove output from JdbcExportArgs, that allows to generate dynamic outputs when working with [flo](https://github.com/spotify/dbeam/flo)
- Adapt tests
- Save queries to file by using `FileSystems.create` instead of defining a `PTransform`, there was no need for that
- `PsqlAvroJob` exposes a `isReplicationDelayed` with `JdbcExportArgs` parameter