### PR TITLE
scio 0.5.2, beam 2.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,8 +20,8 @@ import sbt._
 import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 import xerial.sbt.pack.PackPlugin._
 
-val scioVersion = "0.4.7"
-val beamVersion = "2.2.0"
+val scioVersion = "0.5.2"
+val beamVersion = "2.4.0"
 val autoValueVersion = "1.5.3"
 val slf4jVersion = "1.7.25"
 
@@ -103,9 +103,9 @@ lazy val dbeam = project
       "org.apache.beam" % "beam-runners-direct-java" % beamVersion,
       "org.apache.beam" % "beam-runners-google-cloud-dataflow-java" % beamVersion,
       "org.apache.commons" % "commons-dbcp2" % "2.1.1",
-      "org.postgresql" % "postgresql" % "42.1.+",
+      "org.postgresql" % "postgresql" % "42.2.+",
       "mysql" % "mysql-connector-java" % "5.1.+",
-      "com.google.cloud.sql" % "postgres-socket-factory" % "1.0.4",
+      "com.google.cloud.sql" % "postgres-socket-factory" % "1.0.5",
       "com.google.cloud.sql" % "mysql-socket-factory" % "1.0.4",
       "com.google.auto.value" % "auto-value" % autoValueVersion % "provided",
       "com.spotify" %% "scio-test" % scioVersion % "test",

--- a/dbeam/src/main/scala/com/spotify/dbeam/JdbcAvroJob.scala
+++ b/dbeam/src/main/scala/com/spotify/dbeam/JdbcAvroJob.scala
@@ -19,7 +19,7 @@ package com.spotify.dbeam
 
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
-import java.sql.ResultSet
+import java.sql.{Connection, ResultSet}
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
@@ -44,7 +44,7 @@ object JdbcAvroJob {
     */
   def createSchema(sc: ScioContext, args: JdbcExportArgs): Schema = {
     val startTimeMillis: Long = System.currentTimeMillis()
-    val connection = args.createConnection()
+    val connection: Connection = args.createConnection()
     val avroDoc = args.avroDoc.getOrElse(s"Generate schema from JDBC ResultSet from " +
       s"${args.tableName} ${connection.getMetaData.getURL}")
     val generatedSchema: Schema = JdbcAvroConversions.createSchemaByReadingOneRow(

--- a/dbeam/src/main/scala/com/spotify/dbeam/options/JdbcExportArgs.scala
+++ b/dbeam/src/main/scala/com/spotify/dbeam/options/JdbcExportArgs.scala
@@ -17,11 +17,15 @@
 
 package com.spotify.dbeam.options
 
+import java.util.concurrent.ThreadLocalRandom
+
 import com.spotify.scio._
-import org.apache.beam.sdk.options.{PipelineOptions, PipelineOptionsFactory}
+import org.apache.beam.sdk.options.{ApplicationNameOptions, PipelineOptions, PipelineOptionsFactory}
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{DateTime, Days, Period, ReadablePeriod}
 import org.slf4j.{Logger, LoggerFactory}
+
+import scala.util.Try
 
 case class JdbcExportArgs(driverClass: String,
                           connectionUrl: String,
@@ -90,12 +94,25 @@ object JdbcExportArgs {
     )
   }
 
+  def fromPipelineOptionsConfigured(options: PipelineOptions): JdbcExportArgs = {
+    val args = fromPipelineOptions(options)
+    Try(options.as(classOf[ApplicationNameOptions])).foreach(_.setAppName("JdbcAvroJob"))
+    if (options.getJobName == null) {
+      val dbName = args.createConnection().getCatalog.toLowerCase().replaceAll("[^a-z0-9]", "")
+      val tableName = args.tableName.toLowerCase().replaceAll("[^a-z0-9]", "")
+      val randomPart = Integer.toHexString(ThreadLocalRandom.current().nextInt())
+      options.setJobName(s"dbeam-${dbName}-${tableName}-${randomPart}")
+    }
+    args
+  }
+
   def contextAndArgs(cmdlineArgs: Array[String]): (ScioContext, JdbcExportArgs, String) = {
     PipelineOptionsFactory.register(classOf[JdbcExportPipelineOptions])
     PipelineOptionsFactory.register(classOf[OutputOptions])
-    val opts = PipelineOptionsFactory.fromArgs(cmdlineArgs:_*).withValidation().create()
+    val opts = PipelineOptionsFactory.fromArgs(cmdlineArgs: _*).withValidation().create()
     (ScioContext(opts),
-      JdbcExportArgs.fromPipelineOptions(opts),
+      JdbcExportArgs.fromPipelineOptionsConfigured(opts),
       opts.as(classOf[OutputOptions]).getOutput)
   }
+
 }


### PR DESCRIPTION
- Beam 2.4.0
- Scio 0.5.2
- Default `applicationName` and `jobName` (can be overwritten)