### PR TITLE
all combined: adding Oracle database, --sqlFile feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:18.04
+
+RUN apt-get update
+RUN apt-get install -y gnupg openjdk-8-jdk scala python3 iputils-ping nano
+
+# https://www.scala-sbt.org/1.x/docs/Installing-sbt-on-Linux.html
+RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+
+RUN apt-get update
+RUN apt-get install -y sbt
+
+COPY . /usr/lib/dbeam
+
+CMD ["/bin/bash"]

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ val scioVersion = "0.5.4"
 val beamVersion = "2.4.0"
 val autoValueVersion = "1.5.3"
 val slf4jVersion = "1.7.25"
+val ojdbc8 = System.getenv("ojdbc8_PATH")
 
 def scalacOptions12(scalaVersion: String) = {
   CrossVersion.partialVersion(scalaVersion) match {
@@ -116,6 +117,7 @@ lazy val dbeamCore = project
       "com.spotify" %% "scio-core" % scioVersion,
       "org.slf4j" % "slf4j-simple" % slf4jVersion,
       "org.apache.beam" % "beam-runners-direct-java" % beamVersion,
+      "org.apache.beam" % "beam-runners-google-cloud-dataflow-java" % beamVersion,
       "org.apache.commons" % "commons-dbcp2" % "2.1.1",
       "org.postgresql" % "postgresql" % "42.2.+",
       "mysql" % "mysql-connector-java" % "5.1.+",
@@ -125,6 +127,20 @@ lazy val dbeamCore = project
       "com.spotify" %% "scio-test" % scioVersion % "test",
       "com.h2database" % "h2" % "1.4.196" % "test",
       "com.typesafe.slick" %% "slick" % "3.2.0" % "test"
+    )
+  )
+  .settings(resolvers ++= (
+    if (ojdbc8 != null)
+      (Resolver.mavenLocal) :: Nil
+    else
+      Nil
+    )
+  )
+  .settings(libraryDependencies ++= (
+    if (ojdbc8 != null)
+      ("com.oracle" % "ojdbc8" % "12.2.0.1") :: Nil
+    else
+      Nil
     )
   )
 

--- a/dbeam-core/src/main/scala/com/spotify/dbeam/JdbcAvroConversions.scala
+++ b/dbeam-core/src/main/scala/com/spotify/dbeam/JdbcAvroConversions.scala
@@ -63,7 +63,12 @@ object JdbcAvroConversions {
                        useLogicalTypes: Boolean = false): Schema = {
     val meta = rs.getMetaData
     val tableName = if (meta.getColumnCount > 0) {
-      normalizeForAvro(meta.getTableName(1))
+      val name = meta.getTableName(1)
+      if (name.isEmpty) {
+        "no_table_name"
+      } else {
+        normalizeForAvro(name)
+      }
     } else {
       "no_table_name"
     }

--- a/dbeam-core/src/main/scala/com/spotify/dbeam/JdbcAvroConversions.scala
+++ b/dbeam-core/src/main/scala/com/spotify/dbeam/JdbcAvroConversions.scala
@@ -37,14 +37,14 @@ object JdbcAvroConversions {
   }
 
   def createSchemaByReadingOneRow(connection: Connection,
-                                  tableName: String,
+                                  sqlQuery: String,
                                   avroSchemaNamespace: String,
                                   avroDoc: String,
                                   useLogicalTypes: Boolean = false): Schema = {
     log.info("Creating Avro schema based on the first read row from the database")
     try {
       val statement = connection.createStatement()
-      val rs = statement.executeQuery(s"SELECT * FROM $tableName LIMIT 1")
+      val rs = statement.executeQuery(sqlQuery)
       val schema = JdbcAvroConversions.createAvroSchema(
         rs, avroSchemaNamespace, connection.getMetaData.getURL, avroDoc, useLogicalTypes)
       log.info(s"Schema created successfully. Generated schema: ${schema.toString}")
@@ -84,7 +84,7 @@ object JdbcAvroConversions {
   : SchemaBuilder.FieldAssembler[Schema] = {
     for (i <- 1 to meta.getColumnCount) {
       val columnName: String = if (meta.getColumnName(i).isEmpty) {
-          meta.getColumnLabel(i)
+        meta.getColumnLabel(i)
       } else {
         meta.getColumnName(i)
       }
@@ -150,7 +150,7 @@ object JdbcAvroConversions {
     * org.postgresql.jdbc.TypeInfoCache
     * com.mysql.jdbc.MysqlDefs#mysqlToJavaType(int)
     */
-  def convertFieldToType(r: ResultSet, i: Integer, meta: ResultSetMetaData) : Any = {
+  def convertFieldToType(r: ResultSet, i: Integer, meta: ResultSetMetaData): Any = {
     val ret: Any = meta.getColumnType(i) match {
       case CHAR | CLOB | LONGNVARCHAR | LONGVARCHAR | NCHAR | NVARCHAR | VARCHAR => r.getString(i)
       case BOOLEAN => r.getBoolean(i)
@@ -188,6 +188,7 @@ object JdbcAvroConversions {
       ret
     }
   }
+
   // scalastyle:on cyclomatic.complexity
 
   private def nullableBytes(bts: scala.Array[Byte]): ByteBuffer = {

--- a/dbeam-core/src/main/scala/com/spotify/dbeam/JdbcAvroIO.java
+++ b/dbeam-core/src/main/scala/com/spotify/dbeam/JdbcAvroIO.java
@@ -131,7 +131,7 @@ public class JdbcAvroIO {
     }
 
     @Override
-    public FileBasedSink.Writer<Void, String> createWriter() throws Exception {
+    public FileBasedSink.Writer<Void, String> createWriter() {
       return new JdbcAvroWriter(this, dynamicDestinations, jdbcAvroOptions);
     }
   }
@@ -169,7 +169,7 @@ public class JdbcAvroIO {
     }
 
     public Void getDestination() {
-      return (Void) null;
+      return null;
     }
 
     @SuppressWarnings("deprecation") // uses internal test functionality.
@@ -261,7 +261,9 @@ public class JdbcAvroIO {
       if (rowCount > 0) {
         this.recordCount.inc((this.rowCount % COUNTER_REPORT_EVERY));
         this.msPerMillionRows.set(1000000L * elapsedMs / rowCount);
-        this.rowsPerMinute.set((60*1000L) * rowCount / elapsedMs);
+        if (elapsedMs != 0) {
+          this.rowsPerMinute.set((60 * 1000L) * rowCount / elapsedMs);
+        }
       }
     }
 

--- a/dbeam-core/src/main/scala/com/spotify/dbeam/JdbcAvroJob.scala
+++ b/dbeam-core/src/main/scala/com/spotify/dbeam/JdbcAvroJob.scala
@@ -48,8 +48,13 @@ object JdbcAvroJob {
     val avroDoc = args.avroDoc.getOrElse(s"Generate schema from JDBC ResultSet from " +
       s"'${args.tableName}' or the --sqlFile with ${connection.getMetaData.getURL}")
     // either sql query or table name exists
-    val sqlQuery : String = args.sqlQuery.getOrElse(
-      s"SELECT * FROM ${args.tableName} LIMIT 1")
+    var sqlQuery: String = args.sqlQuery.getOrElse(
+      s"SELECT * FROM ${args.tableName}")
+    if (args.driverClass.equals("oracle.jdbc.OracleDriver")) {
+      sqlQuery = "SELECT * FROM (" + sqlQuery + ") WHERE 1=0"
+    } else {
+      sqlQuery += " LIMIT 1"
+    }
     val generatedSchema: Schema = JdbcAvroConversions.createSchemaByReadingOneRow(
       connection, sqlQuery, args.avroSchemaNamespace, avroDoc, args.useAvroLogicalTypes)
     val elapsedTimeSchema: Long = System.currentTimeMillis() - startTimeMillis

--- a/dbeam-core/src/main/scala/com/spotify/dbeam/options/DBeamPipelineOptions.scala
+++ b/dbeam-core/src/main/scala/com/spotify/dbeam/options/DBeamPipelineOptions.scala
@@ -71,6 +71,13 @@ trait JdbcExportPipelineOptions extends DBeamPipelineOptions {
 
   def setSkipPartitionCheck(value: Boolean): Unit
 
+  @Description("By default, queries are logged in _queries directory. " +
+    "Passing such parameter will not log queries. Use with sensitive data in queries.")
+  @Default.Boolean(false)
+  def isSensitiveProperties: Boolean
+
+  def setSensitiveProperties(value: Boolean): Unit
+
   @Description("The minimum partition required for the job not to fail " +
     "(when partition column is not specified), by default `now() - 2*partitionPeriod`.")
   def getPartitionPeriod: String
@@ -85,6 +92,11 @@ trait JdbcExportPipelineOptions extends DBeamPipelineOptions {
   def getLimit: Integer
 
   def setLimit(value: Integer): Unit
+
+  @Description("Local path to the text file containing the SQL query.")
+  def getSqlFile: String
+
+  def setSqlFile(value: String): Unit
 
   @Description("The namespace of the generated avro schema.")
   @Default.String("dbeam_generated")

--- a/dbeam-core/src/main/scala/com/spotify/dbeam/options/JdbcConnectionArgs.scala
+++ b/dbeam-core/src/main/scala/com/spotify/dbeam/options/JdbcConnectionArgs.scala
@@ -42,14 +42,15 @@ object JdbcConnectionUtil {
   private val driverMapping = Map(
     "postgresql" -> "org.postgresql.Driver",
     "mysql" -> "com.mysql.jdbc.Driver",
-    "h2" -> "org.h2.Driver"
+    "h2" -> "org.h2.Driver",
+    "oracle" -> "oracle.jdbc.OracleDriver"
   )
 
   @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
   def getDriverClass(url: String): String = {
     val parts: Array[String] = url.split(":", 3)
     val errorMsg = s"Invalid jdbc connection URL: $url. " +
-      "Expect jdbc:postgresql or jdbc:mysql as prefix."
+      "Expect jdbc:postgresql, jdbc:oracle, or jdbc:mysql as prefix."
     require(parts(0) == "jdbc",
       errorMsg)
     val mappedClass: Option[String] = driverMapping.get(parts(1))

--- a/dbeam-core/src/test/scala/com/spotify/dbeam/JdbcAvroConversionsTest.scala
+++ b/dbeam-core/src/test/scala/com/spotify/dbeam/JdbcAvroConversionsTest.scala
@@ -34,6 +34,9 @@ class JdbcAvroConversionsTest extends FlatSpec with Matchers with BeforeAndAfter
   private val db: Database = Database.forURL(connectionUrl, driver = "org.h2.Driver")
   private val connection: Connection = db.source.createConnection()
   private val record1 = JdbcTestFixtures.record1
+  def oneRowQuery(tableName:String) : String = {
+    s"SELECT * FROM $tableName LIMIT 1"
+  }
 
   override def beforeAll(): Unit = {
     JdbcTestFixtures.createFixtures(db, Seq(JdbcTestFixtures.record1))
@@ -43,7 +46,7 @@ class JdbcAvroConversionsTest extends FlatSpec with Matchers with BeforeAndAfter
     val fieldCount = 12
     val actual: Schema = JdbcAvroConversions.createSchemaByReadingOneRow(
       db.source.createConnection(),
-      "coffees", "dbeam_generated",
+      oneRowQuery("coffees"), "dbeam_generated",
       "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test")
 
     actual shouldNot be (null)
@@ -80,7 +83,7 @@ class JdbcAvroConversionsTest extends FlatSpec with Matchers with BeforeAndAfter
     val fieldCount = 12
     val actual: Schema = JdbcAvroConversions.createSchemaByReadingOneRow(
       db.source.createConnection(),
-      "coffees", "dbeam_generated",
+      oneRowQuery("coffees"), "dbeam_generated",
       "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test",
       true)
 
@@ -117,7 +120,7 @@ class JdbcAvroConversionsTest extends FlatSpec with Matchers with BeforeAndAfter
 
   it should "create schema under specified namespace" in {
     val actual: Schema = JdbcAvroConversions.createSchemaByReadingOneRow(
-      db.source.createConnection(), "coffees", "ns", "doc")
+      db.source.createConnection(), oneRowQuery("coffees"), "ns", "doc")
 
     actual shouldNot be (null)
     actual.getNamespace should be ("ns")
@@ -125,7 +128,7 @@ class JdbcAvroConversionsTest extends FlatSpec with Matchers with BeforeAndAfter
 
   it should "create schema with specified doc string" in {
     val actual: Schema = JdbcAvroConversions.createSchemaByReadingOneRow(
-      db.source.createConnection(), "coffees", "ns", "doc")
+      db.source.createConnection(), oneRowQuery("coffees"), "ns", "doc")
 
     actual shouldNot be (null)
     actual.getDoc should be ("doc")
@@ -135,7 +138,8 @@ class JdbcAvroConversionsTest extends FlatSpec with Matchers with BeforeAndAfter
     val bf = ByteBuffer.allocate(16)
       .putLong(uuid.getMostSignificantBits)
       .putLong(uuid.getLeastSignificantBits)
-    bf.clear()
+    val buffer: java.nio.Buffer = bf
+    buffer.clear()
     bf
   }
 

--- a/dbeam-core/src/test/scala/com/spotify/dbeam/options/JdbcExportArgsTest.scala
+++ b/dbeam-core/src/test/scala/com/spotify/dbeam/options/JdbcExportArgsTest.scala
@@ -58,6 +58,8 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam_generated",
       None,
       None,
+      true,
+      None,
       None
     ))
   }
@@ -115,6 +117,8 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam_generated",
       None,
       None,
+      true,
+      None,
       None
     ))
   }
@@ -130,6 +134,8 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "some_table",
       "dbeam_generated",
       None,
+      None,
+      true,
       None,
       None
     ))
@@ -147,6 +153,8 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam_generated",
       None,
       None,
+      true,
+      None,
       None
     ))
   }
@@ -162,6 +170,8 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "some_table",
       "dbeam_generated",
       Some(7),
+      None,
+      true,
       None,
       None
     )
@@ -181,6 +191,8 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam_generated",
       None,
       None,
+      true,
+      None,
       Some(new DateTime(2027, 7, 31, 0, 0, DateTimeZone.UTC))
     )
     actual should be (expected)
@@ -198,6 +210,8 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "some_table",
       "dbeam_generated",
       None,
+      None,
+      true,
       None,
       Some(new DateTime(2027, 7, 31, 13, 37, 59, DateTimeZone.UTC))
     )
@@ -217,6 +231,8 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "dbeam_generated",
       None,
       None,
+      true,
+      None,
       Some(new DateTime(2027, 5, 1, 0, 0, 0, DateTimeZone.UTC))
     )
     actual should be (expected)
@@ -234,6 +250,8 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "some_table",
       "dbeam_generated",
       None,
+      None,
+      true,
       Some("col"),
       Some(new DateTime(2027, 7, 31, 0, 0, 0, DateTimeZone.UTC))
     )
@@ -253,6 +271,8 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "some_table",
       "dbeam_generated",
       Some(5),
+      None,
+      true,
       Some("col"),
       Some(new DateTime(2027, 7, 31, 0, 0, 0, DateTimeZone.UTC))
     )
@@ -273,6 +293,8 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "some_table",
       "dbeam_generated",
       None,
+      None,
+      true,
       Some("col"),
       Some(new DateTime(2027, 7, 31, 0, 0, 0, DateTimeZone.UTC)),
       Period.parse("P1M")
@@ -293,6 +315,8 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "some_table",
       "ns",
       None,
+      None,
+      true,
       None,
       None
     ))


### PR DESCRIPTION
I added 3 features in 3 commits. plus, I modified the Readme.md file which fixes [the issues](https://github.com/spotify/dbeam/issues/21) I raised. The changes require having a local maven repository with ojdbc8.jar dependency. I put the command to add that in [my forked DBeam's Readme.md](https://github.com/hilliao/dbeam) Building with ojdbc8.jar:
`mvn install:install-file -Dfile=/usr/local/lib/ojdbc8.jar \
  -DgroupId=com.oracle -DartifactId=ojdbc8 -Dversion=12.2.0.1 -Dpackaging=jar -DgeneratePom=true`
I intend to add more unit tests for the added features but want to get your feedback on my code first. I'm hoping it will create value to your project and the open source community.
