### PR TITLE
Configure avro codec and fetchSize

### DIFF
--- a/dbeam-core/src/main/scala/com/spotify/dbeam/JdbcAvroIO.java
+++ b/dbeam-core/src/main/scala/com/spotify/dbeam/JdbcAvroIO.java
@@ -21,6 +21,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 
 import org.apache.avro.Schema;
+import org.apache.avro.file.Codec;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileConstants;
 import org.apache.avro.file.DataFileWriter;
@@ -62,8 +63,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public class JdbcAvroIO {
 
-  private static final CodecFactory DEFAULT_DEFLATE_CODEC = CodecFactory.deflateCodec(6);
-
   public abstract static class Write {
 
     private static final String DEFAULT_SHARD_TEMPLATE = ShardNameTemplate.INDEX_OF_MAX;
@@ -84,7 +83,7 @@ public class JdbcAvroIO {
       final DynamicAvroDestinations<String, Void, String>
           destinations =
           AvroIO.constantDestinations(filenamePolicy, schema, ImmutableMap.of(),
-                                      DEFAULT_DEFLATE_CODEC,
+                                      CodecFactory.deflateCodec(jdbcAvroOptions.getDeflateCompressionLevel()),
                                       SerializableFunctions.identity());
       final FileBasedSink<String, Void, String> sink = new JdbcAvroSink<>(
           prefixProvider,
@@ -136,7 +135,6 @@ public class JdbcAvroIO {
   }
 
   private static class JdbcAvroWriter extends FileBasedSink.Writer<Void, String> {
-    private static final int FETCH_SIZE = 10000;
     private static final int COUNTER_REPORT_EVERY = 100000;
     private static final int LOG_EVERY = 100000;
     private final Logger logger = LoggerFactory.getLogger(JdbcAvroWriter.class);
@@ -196,13 +194,14 @@ public class JdbcAvroIO {
           query,
           ResultSet.TYPE_FORWARD_ONLY,
           ResultSet.CONCUR_READ_ONLY);
-      statement.setFetchSize(FETCH_SIZE);
+      statement.setFetchSize(jdbcAvroOptions.getFetchSize());
       if (jdbcAvroOptions.getStatementPreparator() != null) {
         jdbcAvroOptions.getStatementPreparator().setParameters(statement);
       }
 
       long startTime = System.currentTimeMillis();
-      logger.info("jdbcavroio : Executing query (this can take a few minutes) ...");
+      logger.info("jdbcavroio : Executing query with fetchSize={} (this can take a few minutes) ...",
+                  statement.getFetchSize());
       ResultSet resultSet = statement.executeQuery();
       long elapsed1 = System.currentTimeMillis() - startTime;
       logger.info(String.format("jdbcavroio : Execute query took %5.2f seconds",
@@ -292,6 +291,8 @@ public class JdbcAvroIO {
     abstract DataSourceConfiguration getDataSourceConfiguration();
     @Nullable abstract StatementPreparator getStatementPreparator();
     abstract RowMapper getAvroRowMapper();
+    abstract int getFetchSize();
+    abstract int getDeflateCompressionLevel();
 
     abstract Builder builder();
 
@@ -300,13 +301,18 @@ public class JdbcAvroIO {
       abstract Builder setDataSourceConfiguration(DataSourceConfiguration dataSourceConfiguration);
       abstract Builder setStatementPreparator(StatementPreparator statementPreparator);
       abstract Builder setAvroRowMapper(RowMapper avroRowMapper);
+      abstract Builder setFetchSize(int fetchSize);
+      abstract Builder setDeflateCompressionLevel(int codecFactory);
       abstract JdbcAvroOptions build();
     }
 
-    public static JdbcAvroOptions create(DataSourceConfiguration dataSourceConfiguration) {
+    public static JdbcAvroOptions create(DataSourceConfiguration dataSourceConfiguration,
+                                         int fetchSize, int deflateCompressionLevel) {
       return new AutoValue_JdbcAvroIO_JdbcAvroOptions.Builder()
           .setDataSourceConfiguration(dataSourceConfiguration)
           .setAvroRowMapper(new DefaultRowMapper())
+          .setFetchSize(fetchSize)
+          .setDeflateCompressionLevel(deflateCompressionLevel)
           .build();
     }
   }

--- a/dbeam-core/src/main/scala/com/spotify/dbeam/JdbcAvroJob.scala
+++ b/dbeam-core/src/main/scala/com/spotify/dbeam/JdbcAvroJob.scala
@@ -78,7 +78,9 @@ object JdbcAvroJob {
     val jdbcAvroOptions = JdbcAvroIO.JdbcAvroOptions.create(
       JdbcAvroIO.DataSourceConfiguration.create(options.driverClass, options.connectionUrl)
         .withUsername(options.username)
-        .withPassword(options.password))
+        .withPassword(options.password),
+      options.fetchSize,
+      options.deflateCompressionLevel)
     JdbcAvroIO.Write.createWrite(
       output,
       ".avro",

--- a/dbeam-core/src/main/scala/com/spotify/dbeam/JdbcAvroJob.scala
+++ b/dbeam-core/src/main/scala/com/spotify/dbeam/JdbcAvroJob.scala
@@ -73,14 +73,14 @@ object JdbcAvroJob {
     * Creates Beam transform to read data from JDBC and save to Avro, in a single step
     */
   def jdbcAvroTransform(output: String,
-                        options: JdbcConnectionArgs,
+                        options: JdbcExportArgs,
                         generatedSchema: Schema): PTransform[PCollection[String], _ <: POutput] = {
     val jdbcAvroOptions = JdbcAvroIO.JdbcAvroOptions.create(
       JdbcAvroIO.DataSourceConfiguration.create(options.driverClass, options.connectionUrl)
         .withUsername(options.username)
         .withPassword(options.password),
       options.fetchSize,
-      options.deflateCompressionLevel)
+      options.avroCodec)
     JdbcAvroIO.Write.createWrite(
       output,
       ".avro",

--- a/dbeam-core/src/main/scala/com/spotify/dbeam/options/DBeamPipelineOptions.scala
+++ b/dbeam-core/src/main/scala/com/spotify/dbeam/options/DBeamPipelineOptions.scala
@@ -107,6 +107,20 @@ trait JdbcExportPipelineOptions extends DBeamPipelineOptions {
   def isUseAvroLogicalTypes: Boolean
 
   def setUseAvroLogicalTypes(value: Boolean): Unit
+
+  @Default.Integer(10000)
+  @Description(
+    "Jdbc result set fetch size.")
+  def getFetchSize: Int
+
+  def setFetchSize(value: Int): Unit
+
+  @Default.Integer(6)
+  @Description(
+    "Avro Deflate codec compression level.")
+  def getDeflateCompressionLevel: Int
+
+  def setDeflateCompressionLevel(value: Int): Unit
 }
 
 trait OutputOptions extends PipelineOptions {

--- a/dbeam-core/src/main/scala/com/spotify/dbeam/options/DBeamPipelineOptions.scala
+++ b/dbeam-core/src/main/scala/com/spotify/dbeam/options/DBeamPipelineOptions.scala
@@ -115,12 +115,12 @@ trait JdbcExportPipelineOptions extends DBeamPipelineOptions {
 
   def setFetchSize(value: Int): Unit
 
-  @Default.Integer(6)
+  @Default.String("deflate6")
   @Description(
-    "Avro Deflate codec compression level.")
-  def getDeflateCompressionLevel: Int
+    "Avro codec (e.g. deflate6, deflate9, snappy).")
+  def getAvroCodec: String
 
-  def setDeflateCompressionLevel(value: Int): Unit
+  def setAvroCodec(value: String): Unit
 }
 
 trait OutputOptions extends PipelineOptions {

--- a/dbeam-core/src/main/scala/com/spotify/dbeam/options/JdbcExportArgs.scala
+++ b/dbeam-core/src/main/scala/com/spotify/dbeam/options/JdbcExportArgs.scala
@@ -39,12 +39,14 @@ case class JdbcExportArgs(driverClass: String,
                           avroDoc: Option[String] = None,
                           useAvroLogicalTypes: Boolean = false,
                           fetchSize: Int = 10000,
-                          deflateCompressionLevel: Int = 6)
+                          avroCodec: String = "deflate6")
   extends JdbcConnectionArgs with QueryArgs {
 
   require(checkTableName(), s"Invalid SQL table name: $tableName")
   require(partitionColumn.isEmpty || partition.isDefined,
     "To use --partitionColumn the --partition parameter must also be configured")
+  require(avroCodec.matches("snappy|deflate[1-9]"),
+    "Avro codec should be snappy or deflate1, .., deflate9")
 
 }
 
@@ -95,7 +97,7 @@ object JdbcExportArgs {
       Option(exportOptions.getAvroDoc),
       exportOptions.isUseAvroLogicalTypes,
       exportOptions.getFetchSize,
-      exportOptions.getDeflateCompressionLevel
+      exportOptions.getAvroCodec
     )
   }
 

--- a/dbeam-core/src/main/scala/com/spotify/dbeam/options/JdbcExportArgs.scala
+++ b/dbeam-core/src/main/scala/com/spotify/dbeam/options/JdbcExportArgs.scala
@@ -37,7 +37,9 @@ case class JdbcExportArgs(driverClass: String,
                           partition: Option[DateTime] = None,
                           partitionPeriod: ReadablePeriod = Days.ONE,
                           avroDoc: Option[String] = None,
-                          useAvroLogicalTypes: Boolean = false)
+                          useAvroLogicalTypes: Boolean = false,
+                          fetchSize: Int = 10000,
+                          deflateCompressionLevel: Int = 6)
   extends JdbcConnectionArgs with QueryArgs {
 
   require(checkTableName(), s"Invalid SQL table name: $tableName")
@@ -91,7 +93,9 @@ object JdbcExportArgs {
       partition,
       partitionPeriod,
       Option(exportOptions.getAvroDoc),
-      exportOptions.isUseAvroLogicalTypes
+      exportOptions.isUseAvroLogicalTypes,
+      exportOptions.getFetchSize,
+      exportOptions.getDeflateCompressionLevel
     )
   }
 

--- a/dbeam-core/src/test/scala/com/spotify/dbeam/options/JdbcExportArgsTest.scala
+++ b/dbeam-core/src/test/scala/com/spotify/dbeam/options/JdbcExportArgsTest.scala
@@ -325,9 +325,9 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       fetchSize=1234
     ))
   }
-  it should "configure compression level" in {
+  it should "configure deflate compression level on avro codec" in {
     val options = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
-      "--password=secret --deflateCompressionLevel=3")
+      "--password=secret --avroCodec=deflate7")
 
     options should be (JdbcExportArgs(
       "org.postgresql.Driver",
@@ -336,7 +336,21 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       "secret",
       "some_table",
       "dbeam_generated",
-      deflateCompressionLevel=3
+      avroCodec = "deflate7"
+    ))
+  }
+  it should "configure snappy as avro codec" in {
+    val options = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
+      "--password=secret --avroCodec=snappy")
+
+    options should be (JdbcExportArgs(
+      "org.postgresql.Driver",
+      "jdbc:postgresql://nonsense",
+      "dbeam-extractor",
+      "secret",
+      "some_table",
+      "dbeam_generated",
+      avroCodec = "snappy"
     ))
   }
 }

--- a/dbeam-core/src/test/scala/com/spotify/dbeam/options/JdbcExportArgsTest.scala
+++ b/dbeam-core/src/test/scala/com/spotify/dbeam/options/JdbcExportArgsTest.scala
@@ -311,4 +311,32 @@ class JdbcExportArgsTest extends FlatSpec with Matchers {
       avroDoc=Some("doc")
     ))
   }
+  it should "configure fetch size" in {
+    val options = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
+      "--password=secret --fetchSize=1234")
+
+    options should be (JdbcExportArgs(
+      "org.postgresql.Driver",
+      "jdbc:postgresql://nonsense",
+      "dbeam-extractor",
+      "secret",
+      "some_table",
+      "dbeam_generated",
+      fetchSize=1234
+    ))
+  }
+  it should "configure compression level" in {
+    val options = optionsFromArgs("--connectionUrl=jdbc:postgresql://nonsense --table=some_table " +
+      "--password=secret --deflateCompressionLevel=3")
+
+    options should be (JdbcExportArgs(
+      "org.postgresql.Driver",
+      "jdbc:postgresql://nonsense",
+      "dbeam-extractor",
+      "secret",
+      "some_table",
+      "dbeam_generated",
+      deflateCompressionLevel=3
+    ))
+  }
 }


### PR DESCRIPTION
Allows more configuration for JDBC fetchSize and Avro codec.
Enables usage for `snappy` for compression: faster but larger output.

About snappy vs deflate, some bechmarks:

- http://java-performance.info/performance-general-compression/
- https://db-blog.web.cern.ch/blog/zbigniew-baranowski/2017-01-performance-comparison-different-file-formats-and-storage-engines
- https://grisha.org/blog/2013/06/11/avro-performance/

Closes #18 