### PR TITLE
Add e2e tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: java
 jdk:
   - oraclejdk8
 
+services:
+  - docker
+
 cache:
   directories:
     - $HOME/.m2/
@@ -20,6 +23,7 @@ env:
 
 script:
   - mvn clean verify -Pcoverage
+  - (cd e2e && ./e2e.sh)
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/e2e/ddl.sql
+++ b/e2e/ddl.sql
@@ -1,0 +1,34 @@
+
+-- This file contatins psql views with complex types to validate and troubleshoot dbeam
+-- import with:
+-- psql -f ddl.sql postgres
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Semi realistic table
+DROP TABLE IF EXISTS demo_table;
+CREATE UNLOGGED TABLE demo_table
+AS
+SELECT
+  n::bigint AS row_number,
+  (trunc(random() * 3)::integer > 0)::boolean AS bool_field,
+  replace(uuid_generate_v4()::text, '-', '') AS hexid1,
+  timestamp '2010-01-01 00:00:00' +
+    random() * (timestamp '2010-01-01 00:00:00' -
+      timestamp '2020-01-01 00:00:00') AS timestamp1,
+  (trunc(random() * 10)::integer + 1) AS tag_field_id,
+  'const' AS flag1,
+  array_to_string(array
+    (SELECT substr('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', trunc(random() * 62)::integer + 1, 1)
+    FROM   generate_series(1, 12)), '') AS random_str2,
+  (ARRAY[NULL, 1.99, 5.99, 99.99, 155.98]::numeric[]
+  )[trunc(random() * 5)::integer + 1] AS numeric_field,
+  timestamp '2010-01-01 00:00:00' +
+    random() * (timestamp '2010-01-01 00:00:00' -
+      timestamp '2020-01-01 00:00:00') AS timestamp2,
+  ARRAY['foo', 'bar']::text[] AS arr1
+FROM
+  generate_series(1,1000000) a(n)
+  ;
+ANALYZE demo_table;
+EXPLAIN ANALYZE SELECT * FROM demo_table;

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+# fail on error
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This file contatins psql views with complex types to validate and troubleshoot dbeam
+
+PSQL_USER=postgres
+PSQL_PASSWORD=mysecretpassword
+PSQL_DB=dbeam_test
+
+startPostgres() {
+  docker run --name dbeam-postgres \
+    -e POSTGRES_DB=dbeam_test \
+    -e POSTGRES_PASSWORD=mysecretpassword \
+    -v /tmp/pgdata:/var/lib/postgresql/data \
+    -p 54321:5432/tcp -d postgres:10 || true
+  # https://stackoverflow.com/questions/35069027/docker-wait-for-postgresql-to-be-running
+  docker run -it --rm --link dbeam-postgres:postgres -e PGPASSWORD=mysecretpassword postgres:10.7 timeout 15s bash -ic 'until psql -h postgres -U postgres dbeam_test -c "select 1"; do sleep 1; done; echo "psql up and running.."'
+  sleep 3
+  cat ./ddl.sql \
+    | docker run -i --rm --link dbeam-postgres:postgres -e PGPASSWORD=mysecretpassword postgres:10 psql -h postgres -U postgres dbeam_test
+  echo '\d' | docker run -i --rm --link dbeam-postgres:postgres -e PGPASSWORD=mysecretpassword postgres:10 psql -h postgres -U postgres dbeam_test
+}
+
+dockerClean() {
+  docker rm -f dbeam-postgres
+}
+
+#"-XX:+PrintGCApplicationStoppedTime"
+#-agentpath:/Applications/VisualVM.app/Contents/profiler/lib/deployed/jdk16/mac/libprofilerinterface.jnilib=/Applications/VisualVM.app/Contents/profiler/lib,5141
+export JAVA_OPTS="
+-XX:+DisableExplicitGC
+-XX:+PrintGCDetails
+-XX:+PrintGCApplicationStoppedTime
+-XX:+PrintGCApplicationConcurrentTime
+-XX:+PrintGCDateStamps
+-Xloggc:gclog.log
+-XX:+UseGCLogFileRotation
+-XX:NumberOfGCLogFiles=5
+-XX:GCLogFileSize=2000k
+-XX:+UseParallelGC
+-Xmx1g
+-Xms1g
+"
+
+pack() {
+  # create a fat jar
+  (cd ..; mvn clean package -Ppack -DskipTests)
+}
+
+runFromJar() {
+  (set -ex; java $JAVA_OPTS -cp ../dbeam-core/target/dbeam-core-shaded.jar com.spotify.dbeam.jobs.JdbcAvroJob "$@")
+}
+
+runDbeamDefault() {
+  time \
+    runFromJar \
+    --skipPartitionCheck \
+    --targetParallelism=1 \
+    "$@" 2>&1 | tee -a /tmp/out1
+}
+
+DOCKER_PSQL_ARGS=(
+  "--username=$PSQL_USER"
+  "--password=$PSQL_PASSWORD"
+  "--connectionUrl=jdbc:postgresql://0.0.0.0:54321/$PSQL_DB?binaryTransfer=${BINARY_TRANSFER:-false}"
+  "--table=${table:-demo_table}"
+)
+
+runDBeamDockerCon() {
+  OUTPUT="./results/testn/$(date +%FT%H%M%S)/"
+  runDbeamDefault \
+    "${DOCKER_PSQL_ARGS[@]}" \
+    "--partition=$(date +%F)" \
+    "--output=$OUTPUT" \
+    "$@"
+}
+
+runScenario() {
+  for ((i=1;i<=3;i++)); do
+    runDBeamDockerCon "${@:2}"
+    jq -r "[\"$1\", .recordCount, .bytesWritten?, .writeElapsedMs, .msPerMillionRows] | @tsv" < "$OUTPUT/_METRICS.json" >> ./bench_dbeam_results
+  done
+}
+
+runSuite() {
+  printf 'scenario\trecords\tbytesWritten\twriteElapsedMs\tmsPerMillionRows\n' >> ./bench_dbeam_results
+  table=demo_table
+  BINARY_TRANSFER='false' runScenario "deflate1t5" --avroCodec=deflate1
+}
+
+
+printResults() {
+  column -t -s $'\t' < ./bench_dbeam_results | tail -n 20
+}
+
+main() {
+  if [[ $# -gt 0 ]]; then
+    "$@"
+  else
+    pack
+    time startPostgres
+
+    runSuite
+    printResults
+    dockerClean
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
Uses Docker, PSQL 10, DirectRunner.

Enables an e2e test, validating that DBeam works correctly with PostgreSQL (in the past we had occasionally introduced a few bugs on type conversions). It also provides some simple benchmark, so we can identify some performance regressions.

Example output:
```
scenario    records     writeElapsedMs  msPerMillionRows
deflate1t5  1000000  9488          9488
deflate1t5  1000000  9932          9932
deflate1t5  1000000  9905          9905
```