### PR TITLE
Add exportTimeout arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ simply streams the table contents via JDBC into target location as Avro.
 - `--passwordFile`: a path to a local file containing the database password
 - `--limit`: limit the output number of rows, indefinite by default
 - `--avroSchemaNamespace`: the namespace of the generated avro schema, `"dbeam_generated"` by default
+- `--exportTimeout`: maximum time the export can take, after this timeout the job is cancelled. Default is `PT23H`.
 - `--partitionColumn`: the name of a date/timestamp column to filter data based on current partition
 - `--partition`: the date of the current partition, parsed using [ISODateTimeFormat.localDateOptionalTimeParser](http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#localDateOptionalTimeParser--)
 - `--partitionPeriod`: the period in which dbeam runs, used to filter based on current partition and also to check if executions are being run for a too old partition

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ simply streams the table contents via JDBC into target location as Avro.
 - `--passwordFile`: a path to a local file containing the database password
 - `--limit`: limit the output number of rows, indefinite by default
 - `--avroSchemaNamespace`: the namespace of the generated avro schema, `"dbeam_generated"` by default
-- `--exportTimeout`: maximum time the export can take, after this timeout the job is cancelled. Default is `PT23H`.
+- `--exportTimeout`: maximum time the export can take, after this timeout the job is cancelled. Default is `PT0S` (no timeout).
 - `--partitionColumn`: the name of a date/timestamp column to filter data based on current partition
 - `--partition`: the date of the current partition, parsed using [ISODateTimeFormat.localDateOptionalTimeParser](http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#localDateOptionalTimeParser--)
 - `--partitionPeriod`: the period in which dbeam runs, used to filter based on current partition and also to check if executions are being run for a too old partition

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
@@ -24,6 +24,7 @@ import com.google.auto.value.AutoValue;
 
 import java.io.Serializable;
 import java.sql.Connection;
+import java.time.Duration;
 import java.util.Optional;
 
 @AutoValue
@@ -39,6 +40,8 @@ public abstract class JdbcExportArgs implements Serializable {
 
   public abstract Boolean useAvroLogicalTypes();
 
+  public abstract Duration exportTimeout();
+
   @AutoValue.Builder
   abstract static class Builder {
 
@@ -52,26 +55,31 @@ public abstract class JdbcExportArgs implements Serializable {
 
     abstract Builder setUseAvroLogicalTypes(Boolean useAvroLogicalTypes);
 
+    abstract Builder setExportTimeout(Duration exportTimeout);
+
     abstract JdbcExportArgs build();
   }
 
   public static JdbcExportArgs create(JdbcAvroArgs jdbcAvroArgs,
                                       QueryBuilderArgs queryBuilderArgs) {
     return create(jdbcAvroArgs, queryBuilderArgs,
-                  "dbeam_generated", Optional.empty(), false);
+                  "dbeam_generated", Optional.empty(), false,
+                  Duration.ofHours(23));
   }
 
   public static JdbcExportArgs create(JdbcAvroArgs jdbcAvroArgs,
                                       QueryBuilderArgs queryBuilderArgs,
                                       String avroSchemaNamespace,
                                       Optional<String> avroDoc,
-                                      Boolean useAvroLogicalTypes) {
+                                      Boolean useAvroLogicalTypes,
+                                      Duration exportTimeout) {
     return new AutoValue_JdbcExportArgs.Builder()
         .setJdbcAvroOptions(jdbcAvroArgs)
         .setQueryBuilderArgs(queryBuilderArgs)
         .setAvroSchemaNamespace(avroSchemaNamespace)
         .setAvroDoc(avroDoc)
         .setUseAvroLogicalTypes(useAvroLogicalTypes)
+        .setExportTimeout(exportTimeout)
         .build();
   }
 

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
@@ -64,7 +64,7 @@ public abstract class JdbcExportArgs implements Serializable {
                                       QueryBuilderArgs queryBuilderArgs) {
     return create(jdbcAvroArgs, queryBuilderArgs,
                   "dbeam_generated", Optional.empty(), false,
-                  Duration.ofHours(23));
+                  Duration.ZERO);
   }
 
   public static JdbcExportArgs create(JdbcAvroArgs jdbcAvroArgs,

--- a/dbeam-core/src/main/java/com/spotify/dbeam/beam/BeamHelper.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/beam/BeamHelper.java
@@ -43,6 +43,15 @@ public class BeamHelper {
   public static PipelineResult waitUntilDone(PipelineResult result,
                                              Duration exportTimeout) {
     PipelineResult.State state = result.waitUntilFinish(exportTimeout);
+    if (!state.isTerminal()) {
+      try {
+        result.cancel();
+      } catch (IOException e) {
+        LOGGER.warn("Job is a state {} and was not possible to cancel", state.toString(), e);
+      }
+      throw new Pipeline.PipelineExecutionException(
+          new Exception("Job cancelled after exceeding timeout " + exportTimeout.toString()));
+    }
     if (!state.equals(PipelineResult.State.DONE)) {
       throw new Pipeline.PipelineExecutionException(
           new Exception("Job finished with state " + state.toString()));

--- a/dbeam-core/src/main/java/com/spotify/dbeam/beam/BeamHelper.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/beam/BeamHelper.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
+import java.time.Duration;
 import java.util.Map;
 
 import org.apache.beam.sdk.Pipeline;
@@ -33,7 +34,6 @@ import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.util.MimeTypes;
-import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +42,9 @@ public class BeamHelper {
 
   public static PipelineResult waitUntilDone(PipelineResult result,
                                              Duration exportTimeout) {
-    PipelineResult.State state = result.waitUntilFinish(exportTimeout);
+    PipelineResult.State state = result.waitUntilFinish(
+        org.joda.time.Duration.millis(
+            exportTimeout.toMillis()));
     if (!state.isTerminal()) {
       try {
         result.cancel();

--- a/dbeam-core/src/main/java/com/spotify/dbeam/beam/BeamHelper.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/beam/BeamHelper.java
@@ -49,7 +49,11 @@ public class BeamHelper {
       try {
         result.cancel();
       } catch (IOException e) {
-        LOGGER.warn("Job is a state {} and was not possible to cancel", state.toString(), e);
+        throw new Pipeline.PipelineExecutionException(
+            new Exception(String.format(
+                "Job exceeded timeout of %s, but was not possible to cancel, "
+                + "finished with state %s",
+                exportTimeout.toString(), state.toString()), e));
       }
       throw new Pipeline.PipelineExecutionException(
           new Exception("Job cancelled after exceeding timeout " + exportTimeout.toString()));

--- a/dbeam-core/src/main/java/com/spotify/dbeam/beam/BeamHelper.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/beam/BeamHelper.java
@@ -33,14 +33,16 @@ import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.util.MimeTypes;
+import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BeamHelper {
   private static Logger LOGGER = LoggerFactory.getLogger(BeamHelper.class);
 
-  public static PipelineResult waitUntilDone(PipelineResult result) {
-    PipelineResult.State state  = result.waitUntilFinish();
+  public static PipelineResult waitUntilDone(PipelineResult result,
+                                             Duration exportTimeout) {
+    PipelineResult.State state = result.waitUntilFinish(exportTimeout);
     if (!state.equals(PipelineResult.State.DONE)) {
       throw new Pipeline.PipelineExecutionException(
           new Exception("Job finished with state " + state.toString()));

--- a/dbeam-core/src/main/java/com/spotify/dbeam/jobs/JdbcAvroJob.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/jobs/JdbcAvroJob.java
@@ -131,7 +131,9 @@ public class JdbcAvroJob {
   }
 
   public PipelineResult runAndWait() {
-    return BeamHelper.waitUntilDone(this.pipeline.run());
+    return BeamHelper.waitUntilDone(this.pipeline.run(),
+                                    org.joda.time.Duration.millis(
+                                        jdbcExportArgs.exportTimeout().toMillis()));
   }
 
   public PipelineResult runExport() throws Exception {

--- a/dbeam-core/src/main/java/com/spotify/dbeam/jobs/JdbcAvroJob.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/jobs/JdbcAvroJob.java
@@ -132,8 +132,7 @@ public class JdbcAvroJob {
 
   public PipelineResult runAndWait() {
     return BeamHelper.waitUntilDone(this.pipeline.run(),
-                                    org.joda.time.Duration.millis(
-                                        jdbcExportArgs.exportTimeout().toMillis()));
+                                    jdbcExportArgs.exportTimeout());
   }
 
   public PipelineResult runExport() throws Exception {

--- a/dbeam-core/src/main/java/com/spotify/dbeam/jobs/JdbcAvroJob.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/jobs/JdbcAvroJob.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.apache.avro.Schema;
+import org.apache.beam.runners.direct.DirectOptions;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -66,6 +67,9 @@ public class JdbcAvroJob {
 
   public static JdbcAvroJob create(PipelineOptions pipelineOptions)
       throws IOException, ClassNotFoundException {
+    // make sure pipeline.run() does not call waitUntilFinish
+    // instead we call with an explicit duration/exportTimeout configuration
+    pipelineOptions.as(DirectOptions.class).setBlockOnRun(false);
     return new JdbcAvroJob(pipelineOptions,
                            Pipeline.create(pipelineOptions),
                            JdbcExportArgsFactory.fromPipelineOptions(pipelineOptions),

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
@@ -26,6 +26,7 @@ import com.spotify.dbeam.args.JdbcConnectionArgs;
 import com.spotify.dbeam.args.JdbcExportArgs;
 import com.spotify.dbeam.args.QueryBuilderArgs;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Optional;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.joda.time.DateTime;
@@ -51,7 +52,8 @@ public class JdbcExportArgsFactory {
         createQueryArgs(exportOptions),
         exportOptions.getAvroSchemaNamespace(),
         Optional.ofNullable(exportOptions.getAvroDoc()),
-        exportOptions.isUseAvroLogicalTypes()
+        exportOptions.isUseAvroLogicalTypes(),
+        Duration.parse(exportOptions.getExportTimeout())
     );
   }
 

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
@@ -104,7 +104,7 @@ public interface JdbcExportPipelineOptions extends DBeamPipelineOptions {
 
   void setQueryParallelism(Integer value);
 
-  @Default.String("PT23H")
+  @Default.String("PT0S")
   @Description(
       "Export timeout, after this duration the export will be terminated.")
   String getExportTimeout();

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
@@ -103,4 +103,11 @@ public interface JdbcExportPipelineOptions extends DBeamPipelineOptions {
   Integer getQueryParallelism();
 
   void setQueryParallelism(Integer value);
+
+  @Default.String("PT23H")
+  @Description(
+      "Export timeout, after this duration the export will be terminated.")
+  String getExportTimeout();
+
+  void setExportTimeout(String value);
 }

--- a/dbeam-core/src/test/scala/com/spotify/dbeam/jobs/BeamHelperTest.scala
+++ b/dbeam-core/src/test/scala/com/spotify/dbeam/jobs/BeamHelperTest.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.dbeam.jobs
+
+import com.spotify.dbeam.beam.BeamHelper
+import org.apache.beam.sdk.Pipeline.PipelineExecutionException
+import org.apache.beam.sdk.PipelineResult
+import org.apache.beam.sdk.metrics.MetricResults
+import org.joda.time.Duration
+import org.junit.runner.RunWith
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+
+
+@RunWith(classOf[JUnitRunner])
+class BeamHelperTest extends FlatSpec with Matchers with BeforeAndAfterAll {
+
+  "BeamHelper" should "throw exception in case pipeline result finish with state FAILED" in {
+    val mockResult = new PipelineResult {
+      override def waitUntilFinish(): PipelineResult.State = null
+      override def getState: PipelineResult.State = null
+      override def cancel(): PipelineResult.State = null
+      override def waitUntilFinish(duration: Duration): PipelineResult.State = PipelineResult.State.FAILED
+      override def metrics(): MetricResults = null
+    }
+
+    the[PipelineExecutionException] thrownBy {
+      BeamHelper.waitUntilDone(mockResult, Duration.standardMinutes(1))
+    } should have message "java.lang.Exception: Job finished with state FAILED"
+  }
+
+  "BeamHelper" should "cancel in case of timeout" in {
+    val mockResult = new PipelineResult {
+      override def waitUntilFinish(): PipelineResult.State = null
+      override def getState: PipelineResult.State = null
+      override def cancel(): PipelineResult.State = null
+      override def waitUntilFinish(duration: Duration): PipelineResult.State = PipelineResult.State.RUNNING
+      override def metrics(): MetricResults = null
+    }
+
+    the[PipelineExecutionException] thrownBy {
+      BeamHelper.waitUntilDone(mockResult, Duration.standardMinutes(1))
+    } should have message "java.lang.Exception: Job cancelled after exceeding timeout PT60S"
+  }
+
+}

--- a/dbeam-core/src/test/scala/com/spotify/dbeam/jobs/BeamHelperTest.scala
+++ b/dbeam-core/src/test/scala/com/spotify/dbeam/jobs/BeamHelperTest.scala
@@ -18,10 +18,12 @@
 package com.spotify.dbeam.jobs
 
 import com.spotify.dbeam.beam.BeamHelper
+
+import java.time.Duration
+
 import org.apache.beam.sdk.Pipeline.PipelineExecutionException
 import org.apache.beam.sdk.PipelineResult
 import org.apache.beam.sdk.metrics.MetricResults
-import org.joda.time.Duration
 import org.junit.runner.RunWith
 import org.scalatest._
 import org.scalatest.junit.JUnitRunner
@@ -35,12 +37,13 @@ class BeamHelperTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       override def waitUntilFinish(): PipelineResult.State = null
       override def getState: PipelineResult.State = null
       override def cancel(): PipelineResult.State = null
-      override def waitUntilFinish(duration: Duration): PipelineResult.State = PipelineResult.State.FAILED
+      override def waitUntilFinish(duration: org.joda.time.Duration): PipelineResult.State =
+        PipelineResult.State.FAILED
       override def metrics(): MetricResults = null
     }
 
     the[PipelineExecutionException] thrownBy {
-      BeamHelper.waitUntilDone(mockResult, Duration.standardMinutes(1))
+      BeamHelper.waitUntilDone(mockResult, Duration.ofMinutes(1))
     } should have message "java.lang.Exception: Job finished with state FAILED"
   }
 
@@ -49,13 +52,14 @@ class BeamHelperTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       override def waitUntilFinish(): PipelineResult.State = null
       override def getState: PipelineResult.State = null
       override def cancel(): PipelineResult.State = null
-      override def waitUntilFinish(duration: Duration): PipelineResult.State = PipelineResult.State.RUNNING
+      override def waitUntilFinish(duration: org.joda.time.Duration): PipelineResult.State =
+        PipelineResult.State.RUNNING
       override def metrics(): MetricResults = null
     }
 
     the[PipelineExecutionException] thrownBy {
-      BeamHelper.waitUntilDone(mockResult, Duration.standardMinutes(1))
-    } should have message "java.lang.Exception: Job cancelled after exceeding timeout PT60S"
+      BeamHelper.waitUntilDone(mockResult, Duration.ofMinutes(1))
+    } should have message "java.lang.Exception: Job cancelled after exceeding timeout PT1M"
   }
 
 }

--- a/dbeam-core/src/test/scala/com/spotify/dbeam/jobs/JdbcAvroJobTest.scala
+++ b/dbeam-core/src/test/scala/com/spotify/dbeam/jobs/JdbcAvroJobTest.scala
@@ -95,20 +95,6 @@ class JdbcAvroJobTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     records should have size 2
   }
 
-  "JdbcAvroJob" should "throw exception in case pipeline result finish with state FAILED" in {
-    val mockResult = new PipelineResult {
-      override def waitUntilFinish(): PipelineResult.State = null
-      override def getState: PipelineResult.State = null
-      override def cancel(): PipelineResult.State = null
-      override def waitUntilFinish(duration: Duration): PipelineResult.State = PipelineResult.State.FAILED
-      override def metrics(): MetricResults = null
-    }
-
-    the[PipelineExecutionException] thrownBy {
-      BeamHelper.waitUntilDone(mockResult, Duration.standardMinutes(1))
-    } should have message "java.lang.Exception: Job finished with state FAILED"
-  }
-
   "JdbcAvroJob" should "have a default exit code" in {
     ExceptionHandling.exitCode(new IllegalStateException()) should be (49)
   }

--- a/dbeam-core/src/test/scala/com/spotify/dbeam/jobs/JdbcAvroJobTest.scala
+++ b/dbeam-core/src/test/scala/com/spotify/dbeam/jobs/JdbcAvroJobTest.scala
@@ -24,17 +24,12 @@ import java.util.{Comparator, UUID}
 
 import com.spotify.dbeam.JdbcTestFixtures
 import com.spotify.dbeam.avro.JdbcAvroMetering
-import com.spotify.dbeam.beam.BeamHelper
 import com.spotify.dbeam.options.OutputOptions
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
-import org.apache.beam.sdk.Pipeline.PipelineExecutionException
-import org.apache.beam.sdk.PipelineResult
 import org.apache.beam.sdk.io.AvroSource
-import org.apache.beam.sdk.metrics.MetricResults
 import org.apache.beam.sdk.options.PipelineOptionsFactory
 import org.apache.beam.sdk.testing.SourceTestUtils
-import org.joda.time.Duration
 import org.junit.runner.RunWith
 import org.scalatest._
 import org.scalatest.junit.JUnitRunner

--- a/dbeam-core/src/test/scala/com/spotify/dbeam/jobs/JdbcAvroJobTest.scala
+++ b/dbeam-core/src/test/scala/com/spotify/dbeam/jobs/JdbcAvroJobTest.scala
@@ -74,6 +74,7 @@ class JdbcAvroJobTest extends FlatSpec with Matchers with BeforeAndAfterAll {
         "--targetParallelism=1",  // no need for more threads when testing
         "--partition=2025-02-28",
         "--skipPartitionCheck",
+        "--exportTimeout=PT1M",
         "--connectionUrl=" + connectionUrl,
         "--username=",
         "--passwordFile=" + passwordFile.getAbsolutePath,
@@ -96,15 +97,15 @@ class JdbcAvroJobTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   "JdbcAvroJob" should "throw exception in case pipeline result finish with state FAILED" in {
     val mockResult = new PipelineResult {
-      override def waitUntilFinish(): PipelineResult.State = PipelineResult.State.FAILED
+      override def waitUntilFinish(): PipelineResult.State = null
       override def getState: PipelineResult.State = null
       override def cancel(): PipelineResult.State = null
-      override def waitUntilFinish(duration: Duration): PipelineResult.State = null
+      override def waitUntilFinish(duration: Duration): PipelineResult.State = PipelineResult.State.FAILED
       override def metrics(): MetricResults = null
     }
 
     the[PipelineExecutionException] thrownBy {
-      BeamHelper.waitUntilDone(mockResult)
+      BeamHelper.waitUntilDone(mockResult, Duration.standardMinutes(1))
     } should have message "java.lang.Exception: Job finished with state FAILED"
   }
 


### PR DESCRIPTION
This allows users to configure DBeam to timeout when waiting for Beam's Pipeline to finish takes to long.

Successfully tested with:

```
$ ./e2e.sh runScenario "shorttimeout" --exportTimeout=PT4S
...
        at com.spotify.dbeam.beam.BeamHelper.waitUntilDone(BeamHelper.java:60)
        at com.spotify.dbeam.jobs.JdbcAvroJob.runAndWait(JdbcAvroJob.java:138)
        at com.spotify.dbeam.jobs.JdbcAvroJob.runExport(JdbcAvroJob.java:144)
        at com.spotify.dbeam.jobs.JdbcAvroJob.main(JdbcAvroJob.java:151)
Caused by: java.lang.Exception: Job cancelled after exceeding timeout PT4S
```