### PR TITLE
Improve throughput

### DIFF
--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/AvroWriter.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/AvroWriter.java
@@ -26,9 +26,15 @@ import java.util.concurrent.BlockingQueue;
 
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Takes ByteBuffer datums from a BlockingQueue and writes to a DataFileWriter.
+ */
 public class AvroWriter implements Runnable {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(AvroWriter.class);
   private final DataFileWriter<GenericRecord> dataFileWriter;
   private final JdbcAvroMetering metering;
   private final BlockingQueue<ByteBuffer> queue;

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/AvroWriter.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/AvroWriter.java
@@ -1,0 +1,64 @@
+/*-
+ * -\-\-
+ * DBeam Core
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.dbeam.avro;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.BlockingQueue;
+
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericRecord;
+
+public class AvroWriter implements Runnable {
+
+  private final DataFileWriter<GenericRecord> dataFileWriter;
+  private final JdbcAvroMetering metering;
+  private final BlockingQueue<ByteBuffer> queue;
+
+  public AvroWriter(
+      DataFileWriter<GenericRecord> dataFileWriter,
+      JdbcAvroMetering metering,
+      BlockingQueue<ByteBuffer> queue) {
+    this.dataFileWriter = dataFileWriter;
+    this.metering = metering;
+    this.queue = queue;
+  }
+
+  @Override
+  public void run() {
+    try {
+      while (true) {
+        final ByteBuffer datum = queue.take();
+        if (datum.capacity() == 0) {
+          this.dataFileWriter.sync();
+          return;
+        } else {
+          this.dataFileWriter.appendEncoded(datum);
+        }
+      }
+    } catch (InterruptedException ex) {
+      System.out.println("CONSUMER INTERRUPTED");
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+  }
+}

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/AvroWriter.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/AvroWriter.java
@@ -36,20 +36,18 @@ public class AvroWriter implements Runnable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AvroWriter.class);
   private final DataFileWriter<GenericRecord> dataFileWriter;
-  private final JdbcAvroMetering metering;
   private final BlockingQueue<ByteBuffer> queue;
 
   public AvroWriter(
       DataFileWriter<GenericRecord> dataFileWriter,
-      JdbcAvroMetering metering,
       BlockingQueue<ByteBuffer> queue) {
     this.dataFileWriter = dataFileWriter;
-    this.metering = metering;
     this.queue = queue;
   }
 
   @Override
   public void run() {
+    LOGGER.debug("AvroWriter started");
     try {
       while (true) {
         final ByteBuffer datum = queue.take();
@@ -61,10 +59,9 @@ public class AvroWriter implements Runnable {
         }
       }
     } catch (InterruptedException ex) {
-      System.out.println("CONSUMER INTERRUPTED");
+      LOGGER.warn("AvroWriter interrupted");
     } catch (IOException e) {
-      e.printStackTrace();
+      LOGGER.error("Error on AvroWriter", e);
     }
-
   }
 }

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroIO.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroIO.java
@@ -25,12 +25,22 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CountingOutputStream;
 import com.spotify.dbeam.args.JdbcAvroArgs;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingDeque;
+
 import org.apache.avro.Schema;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileConstants;
@@ -136,6 +146,7 @@ public class JdbcAvroIO {
     private Connection connection;
     private JdbcAvroMetering metering;
     private CountingOutputStream countingOutputStream;
+    private BlockingQueue<ByteBuffer> queue;
 
     JdbcAvroWriter(
         FileBasedSink.WriteOperation<Void, String> writeOperation,
@@ -145,6 +156,7 @@ public class JdbcAvroIO {
       this.dynamicDestinations = dynamicDestinations;
       this.jdbcAvroArgs = jdbcAvroArgs;
       this.metering = JdbcAvroMetering.create();
+      this.queue = new LinkedBlockingDeque<>(jdbcAvroArgs.fetchSize() * 4);
     }
 
     public Void getDestination() {
@@ -199,16 +211,25 @@ public class JdbcAvroIO {
     public void write(final String query) throws Exception {
       checkArgument(dataFileWriter != null, "Avro DataFileWriter was not properly created");
       LOGGER.info("jdbcavroio : Starting write...");
+      final ExecutorService executorService = Executors.newSingleThreadExecutor();
       try (ResultSet resultSet = executeQuery(query)) {
-        metering.startWriteMeter();
-        final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(resultSet);
-        while (resultSet.next()) {
-          dataFileWriter.appendEncoded(converter.convertResultSetIntoAvroBytes());
-          this.metering.incrementRecordCount();
-        }
+        final Future<?> future = executorService.submit(new AvroWriter(dataFileWriter, metering, queue));
+        final long startMs = metering.startWriteMeter();
+        convertAllResultSet(resultSet, JdbcAvroRecordConverter.create(resultSet));
+        queue.put(ByteBuffer.allocate(0)); // write final record, so that consumer stops
+        future.get();
+        executorService.shutdown();
         this.dataFileWriter.flush();
         this.metering.exposeWriteElapsed();
         this.metering.exposeWrittenBytes(this.countingOutputStream.getCount());
+      }
+    }
+
+    private void convertAllResultSet(ResultSet resultSet, JdbcAvroRecordConverter converter)
+        throws SQLException, InterruptedException, IOException {
+      while (resultSet.next()) {
+        queue.put(converter.convertResultSetIntoAvroBytes());
+        this.metering.incrementRecordCount();
       }
     }
 

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroIO.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroIO.java
@@ -166,7 +166,7 @@ public class JdbcAvroIO {
     @SuppressWarnings("deprecation") // uses internal test functionality.
     @Override
     protected void prepareWrite(final WritableByteChannel channel) throws Exception {
-      LOGGER.info("jdbcavroio : Preparing write...");
+      LOGGER.debug("jdbcavroio : Preparing write...");
       connection = jdbcAvroArgs.jdbcConnectionConfiguration().createConnection();
       final Void destination = getDestination();
       final Schema schema = dynamicDestinations.getSchema(destination);
@@ -177,7 +177,7 @@ public class JdbcAvroIO {
       dataFileWriter.setMeta("created_by", this.getClass().getCanonicalName());
       this.countingOutputStream = new CountingOutputStream(Channels.newOutputStream(channel));
       dataFileWriter.create(schema, this.countingOutputStream);
-      LOGGER.info("jdbcavroio : Write prepared");
+      LOGGER.debug("jdbcavroio : Write prepared");
     }
 
     private ResultSet executeQuery(final String query) throws Exception {
@@ -238,7 +238,7 @@ public class JdbcAvroIO {
 
     @Override
     protected void finishWrite() throws Exception {
-      LOGGER.info("jdbcavroio : Closing connection, flushing writer...");
+      LOGGER.debug("jdbcavroio : Closing connection, flushing writer...");
       if (connection != null) {
         connection.close();
       }


### PR DESCRIPTION
1. Encode JDBC ResultSet into ByteBuffer using `directBinaryEncoder`, write using `appendEncoded()`. This avoids a bit of copying bytes between buffers.
2. Use a `BlockingQueue` to asynchronously read from JDBC and write to file.

Early experiments show that it can improve throughput by ~ 15 ~ 30 %.


`master`/#60 (https://travis-ci.org/spotify/dbeam/builds/520639708#L1545):

```
scenario    records  writeElapsedMs  msPerMillionRows  bytesWritten  kBps
deflate1t5  1000000  10288           10288             43722188      4249.823
deflate1t5  1000000  9884            9884              43722188      4423.531
deflate1t5  1000000  9819            9819              43722188      4452.814
||query     1000000  9888            8570              61220677      6191.411
||query     1000000  9835            8620              52475971      5335.635
||query     1000000  9874            8380              52475971      5314.56
````

#61 (just encode to binary, no multi threading) (https://travis-ci.org/spotify/dbeam/builds/520647554#L1524):

```
scenario    records  writeElapsedMs  msPerMillionRows  bytesWritten  kBps
deflate1t5  1000000  9674            9674              53403623      5520.324
deflate1t5  1000000  9407            9407              53403623      5677.008
deflate1t5  1000000  9396            9396              53403623      5683.655
||query     1000000  9484            8580              53411427      5631.74
||query     1000000  9596            8705              74772355      7792.033
||query     1000000  9800            9130              53411427      5450.145
```

This PR (https://travis-ci.org/spotify/dbeam/builds/520648264#L1539):

```
scenario    records  writeElapsedMs  msPerMillionRows  bytesWritten  kBps
deflate1t5  1000000  8464            8464              53406242      6309.811
deflate1t5  1000000  7791            7791              53406242      6854.863
deflate1t5  1000000  7741            7741              53406242      6899.139
||query     1000000  8110            7350              74773099      9219.864
||query     1000000  8510            7075              74773099      8786.498
||query     1000000  8204            7330              64093112      7812.422
```