### PR TITLE
Fix Monthly partition support

### DIFF
--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
@@ -32,6 +32,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.Period;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
@@ -91,7 +92,13 @@ public class JdbcExportArgsFactory {
     if (!(options.isSkipPartitionCheck() || partitionColumn.isPresent())) {
       Instant minPartitionDateTime = Optional.ofNullable(options.getMinPartitionPeriod())
           .map(JdbcExportArgsFactory::parseInstant)
-          .orElse(Instant.now().minus(partitionPeriod.multipliedBy(2)));
+          // given Instant does not support operations with ChronoUnit.MONTHS
+          .orElse(
+              Instant.now()
+                .atOffset(ZoneOffset.UTC)
+                .minus(partitionPeriod.multipliedBy(2))
+                .toInstant()
+              );
       partition.map(p -> validatePartition(p, minPartitionDateTime));
     }
 

--- a/dbeam-core/src/test/java/com/spotify/dbeam/args/JdbcExportOptionsTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/args/JdbcExportOptionsTest.java
@@ -24,6 +24,7 @@ import com.spotify.dbeam.options.JdbcExportArgsFactory;
 import com.spotify.dbeam.options.JdbcExportPipelineOptions;
 
 import java.io.IOException;
+import java.time.Period;
 import java.util.Optional;
 
 import org.apache.avro.file.CodecFactory;
@@ -200,6 +201,19 @@ public class JdbcExportOptionsTest {
     Assert.assertEquals(
         1234,
         options.jdbcAvroOptions().fetchSize());
+  }
+
+  @Test
+  public void shouldSupportMonthlyPartitionPeriod() throws IOException, ClassNotFoundException {
+    // Given handling ChronoUnit.MONTHS is not always simple
+    // https://stackoverflow.com/q/39907925/1046584
+    JdbcExportArgs options = optionsFromArgs(
+        "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
+        + "--password=secret --partitionPeriod=P1M --partition=2050-12");
+
+    Assert.assertEquals(
+        Period.ofMonths(1),
+        options.queryBuilderArgs().partitionPeriod());
   }
 
   @Test


### PR DESCRIPTION
On 43e826bba5e7563dd64ce686da8747b281b84f7b , we moved from org.joda.time to
java.time. That introduced a bug not covered by unit tests.

This adds a unit test for `--partitionPeriod=P1M` for
`JdbcExportArgsFactory` and fixes the bug.

Some more details at: https://stackoverflow.com/q/39907925/1046584