### PR TITLE
Support hourly period

### DIFF
--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcConnectionUtil.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcConnectionUtil.java
@@ -29,7 +29,7 @@ public class JdbcConnectionUtil {
   private static Map<String, String> driverMapping =
       ImmutableMap.of(
           "postgresql", "org.postgresql.Driver",
-          "mysql", "com.mysql.jdbc.Driver",
+          "mysql", "com.mysql.cj.jdbc.Driver",
           "h2", "org.h2.Driver");
 
   public static String getDriverClass(final String url) throws ClassNotFoundException {

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/ParallelQueryBuilder.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/ParallelQueryBuilder.java
@@ -118,12 +118,11 @@ public class ParallelQueryBuilder implements Serializable {
 
     return ranges.stream()
         .map(
-            x ->
-                queryBuilder
-                    .copy() // we create a new query here
-                    .withParallelizationCondition(
-                        splitColumn, x.getStartPointIncl(), x.getEndPoint(), x.isEndPointExcl())
-                    .build())
+            x -> queryBuilder
+                .withParallelizationCondition(
+                    splitColumn, x.getStartPointIncl(), x.getEndPoint(), x.isEndPointExcl())
+                .build()
+        )
         .collect(Collectors.toList());
   }
 

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/QueryBuilderArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/QueryBuilderArgs.java
@@ -41,7 +41,7 @@ import java.util.Optional;
 @AutoValue
 public abstract class QueryBuilderArgs implements Serializable {
 
-  public abstract QueryBuilder baseSqlQuery();
+  abstract QueryBuilder baseSqlQuery();
 
   public abstract Optional<Long> limit();
 
@@ -112,8 +112,7 @@ public abstract class QueryBuilderArgs implements Serializable {
    * @return
    */
   public String sqlQueryWithLimitOne() {
-    // need to copy, since baseSqlQuery is mutable
-    return this.baseSqlQuery().copy().withLimitOne().build();
+    return this.baseSqlQuery().withLimit(1L).build();
   }
 
   /**
@@ -124,39 +123,46 @@ public abstract class QueryBuilderArgs implements Serializable {
    * @throws SQLException when it fails to find out limits for splits.
    */
   public List<String> buildQueries(final Connection connection) throws SQLException {
-    this.partitionColumn().ifPresent(partitionColumn ->
-        this.partition().ifPresent(partition ->
-          configurePartitionCondition(partitionColumn, partition, partitionPeriod())
-        ));
-    this.limit()
-        .ifPresent(
-            l -> this.baseSqlQuery().withLimit(queryParallelism().map(k -> l / k).orElse(l)));
+    QueryBuilder queryBuilder = this.baseSqlQuery();
+    if (this.partitionColumn().isPresent() && this.partition().isPresent()) {
+      queryBuilder = configurePartitionCondition(
+          this.partitionColumn().get(),
+          this.partition().get(),
+          partitionPeriod(),
+          queryBuilder);
+    }
+    if (this.limit().isPresent()) {
+      queryBuilder = queryBuilder
+          .withLimit(queryParallelism().map(k -> limit().get() / k).orElse(limit().get()));
+    }
 
     if (queryParallelism().isPresent() && splitColumn().isPresent()) {
-      long[] minMax = findInputBounds(connection, this.baseSqlQuery(), splitColumn().get());
+      long[] minMax = findInputBounds(connection, queryBuilder, splitColumn().get());
       long min = minMax[0];
       long max = minMax[1];
 
       return queriesForBounds(
-          min, max, queryParallelism().get(), splitColumn().get(), this.baseSqlQuery());
+          min, max, queryParallelism().get(), splitColumn().get(), queryBuilder);
     } else {
-      return Lists.newArrayList(this.baseSqlQuery().build());
+      return Lists.newArrayList(queryBuilder.build());
     }
   }
 
-  private void configurePartitionCondition(final String partitionColumn, final Instant partition,
-                                           final TemporalAmount partitionPeriod) {
+  private QueryBuilder configurePartitionCondition(final String partitionColumn,
+                                                   final Instant partition,
+                                                   final TemporalAmount partitionPeriod,
+                                                   final QueryBuilder queryBuilder) {
     if (partitionPeriod() instanceof Period) {
       final LocalDate partitionDate = partition.atZone(ZoneOffset.UTC).toLocalDate();
       final LocalDate nextPartition = partitionDate.plus(partitionPeriod);
-      this.baseSqlQuery().withPartitionCondition(
+      return queryBuilder.withPartitionCondition(
           partitionColumn,
           partitionDate.toString(),
           nextPartition.toString());
     } else {
       // in case of sub daily period, use the full timestamp
-      final Instant nextPartition = partition.plus(partitionPeriod());
-      this.baseSqlQuery().withPartitionCondition(
+      final Instant nextPartition = partition.plus(partitionPeriod);
+      return queryBuilder.withPartitionCondition(
               partitionColumn, partition.toString(), nextPartition.toString());
     }
   }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderArgsTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderArgsTest.java
@@ -78,12 +78,12 @@ public class QueryBuilderArgsTest {
   }
 
   @Test
-  public void shouldCreateValidSqlQueryFromUserQuery() {
+  public void shouldCreateValidSqlQueryFromUserQuery() throws SQLException {
     QueryBuilderArgs args = QueryBuilderArgs.createFromQuery("SELECT * FROM some_table");
 
     Assert.assertEquals(
-        "SELECT * FROM (SELECT * FROM some_table) as user_sql_query WHERE 1=1",
-        args.baseSqlQuery().build());
+        Lists.newArrayList("SELECT * FROM (SELECT * FROM some_table) as user_sql_query WHERE 1=1"),
+        args.buildQueries(null));
   }
 
   @Test
@@ -181,7 +181,8 @@ public class QueryBuilderArgsTest {
   }
 
   @Test
-  public void shouldConfigurePartitionColumnAndPartitionPeriodForHourly() throws IOException, SQLException {
+  public void shouldConfigurePartitionColumnAndPartitionPeriodForHourly()
+      throws IOException, SQLException {
     QueryBuilderArgs actual =
         parseOptions(
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "

--- a/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderArgsTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderArgsTest.java
@@ -180,6 +180,20 @@ public class QueryBuilderArgsTest {
         actual.buildQueries(null));
   }
 
+  @Test
+  public void shouldConfigurePartitionColumnAndPartitionPeriodForHourly() throws IOException, SQLException {
+    QueryBuilderArgs actual =
+        parseOptions(
+            "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
+                + "--partition=2027-07-31T00 --partitionColumn=col --partitionPeriod=PT1H");
+
+    Assert.assertEquals(
+        Lists.newArrayList(
+            "SELECT * FROM some_table WHERE 1=1 "
+                + "AND col >= '2027-07-31T00:00:00Z' AND col < '2027-07-31T01:00:00Z'"),
+        actual.buildQueries(null));
+  }
+
   // tests for --sqlFile parameter
 
   @Test

--- a/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderArgsTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderArgsTest.java
@@ -89,7 +89,7 @@ public class QueryBuilderArgsTest {
   @Test
   public void shouldConfigureLimit() throws IOException, SQLException {
     QueryBuilderArgs actual =
-        pareOptions("--connectionUrl=jdbc:postgresql://some_db --table=some_table " + "--limit=7");
+        parseOptions("--connectionUrl=jdbc:postgresql://some_db --table=some_table " + "--limit=7");
 
     Assert.assertEquals(
         Lists.newArrayList("SELECT * FROM some_table WHERE 1=1 LIMIT 7"),
@@ -99,7 +99,7 @@ public class QueryBuilderArgsTest {
   @Test
   public void shouldConfigurePartition() throws IOException, SQLException {
     QueryBuilderArgs actual =
-        pareOptions(
+        parseOptions(
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-07-31");
 
@@ -111,7 +111,7 @@ public class QueryBuilderArgsTest {
   @Test
   public void shouldConfigurePartitionForFullIsoString() throws IOException, SQLException {
     QueryBuilderArgs actual =
-        pareOptions(
+        parseOptions(
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-07-31T13:37:59Z");
 
@@ -121,7 +121,7 @@ public class QueryBuilderArgsTest {
   @Test
   public void shouldConfigurePartitionForMonthlySchedule() throws IOException, SQLException {
     QueryBuilderArgs actual =
-        pareOptions(
+        parseOptions(
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-05");
 
@@ -131,7 +131,7 @@ public class QueryBuilderArgsTest {
   @Test
   public void shouldConfigurePartitionForHourlySchedule() throws IOException, SQLException {
     QueryBuilderArgs actual =
-        pareOptions(
+        parseOptions(
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-05-02T23");
 
@@ -141,7 +141,7 @@ public class QueryBuilderArgsTest {
   @Test
   public void shouldConfigurePartitionColumn() throws IOException, SQLException {
     QueryBuilderArgs actual =
-        pareOptions(
+        parseOptions(
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-07-31 --partitionColumn=col");
 
@@ -155,7 +155,7 @@ public class QueryBuilderArgsTest {
   @Test
   public void shouldConfigurePartitionColumnAndLimit() throws IOException, SQLException {
     QueryBuilderArgs actual =
-        pareOptions(
+        parseOptions(
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-07-31 --partitionColumn=col --limit=5");
 
@@ -169,7 +169,7 @@ public class QueryBuilderArgsTest {
   @Test
   public void shouldConfigurePartitionColumnAndPartitionPeriod() throws IOException, SQLException {
     QueryBuilderArgs actual =
-        pareOptions(
+        parseOptions(
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-07-31 --partitionColumn=col --partitionPeriod=P1M");
 
@@ -185,7 +185,7 @@ public class QueryBuilderArgsTest {
   @Test
   public void shouldConfigureLimitForSqlFile() throws IOException, SQLException {
     QueryBuilderArgs actual =
-        pareOptions(
+        parseOptions(
             String.format(
                 "--connectionUrl=jdbc:postgresql://some_db " + "--sqlFile=%s --limit=7",
                 coffeesSqlQueryPath.toString()));
@@ -200,7 +200,7 @@ public class QueryBuilderArgsTest {
   @Test
   public void shouldConfigurePartitionColumnAndLimitForSqlFile() throws IOException, SQLException {
     QueryBuilderArgs actual =
-        pareOptions(
+        parseOptions(
             String.format(
                 "--connectionUrl=jdbc:postgresql://some_db "
                     + "--sqlFile=%s --partition=2027-07-31 --partitionColumn=col --limit=7",
@@ -217,7 +217,7 @@ public class QueryBuilderArgsTest {
   public void shouldConfigurePartitionColumnAndPartitionPeriodForSqlFile()
       throws IOException, SQLException {
     QueryBuilderArgs actual =
-        pareOptions(
+        parseOptions(
             String.format(
                 "--connectionUrl=jdbc:postgresql://some_db "
                     + "--sqlFile=%s --partition=2027-07-31 "
@@ -235,7 +235,7 @@ public class QueryBuilderArgsTest {
   @Test
   public void shouldCreateParallelQueries() throws IOException, SQLException {
     QueryBuilderArgs actual =
-        pareOptions(
+        parseOptions(
             "--connectionUrl=jdbc:postgresql://some_db --table=COFFEES "
                 + "--splitColumn=ROWNUM --queryParallelism=5");
 
@@ -247,7 +247,7 @@ public class QueryBuilderArgsTest {
   @Test
   public void shouldCreateParallelQueriesWithSqlFile() throws IOException, SQLException {
     QueryBuilderArgs actual =
-        pareOptions(
+        parseOptions(
             String.format(
                 "--connectionUrl=jdbc:postgresql://some_db "
                     + "--sqlFile=%s --splitColumn=ROWNUM --queryParallelism=5",
@@ -263,7 +263,7 @@ public class QueryBuilderArgsTest {
   @Test
   public void shouldCreateParallelQueriesWithPartitionColumn() throws IOException, SQLException {
     QueryBuilderArgs actual =
-        pareOptions(
+        parseOptions(
             String.format(
                 "--connectionUrl=jdbc:postgresql://some_db "
                     + "--sqlFile=%s --partition=2027-07-31 "
@@ -277,7 +277,7 @@ public class QueryBuilderArgsTest {
         actual.buildQueries(connection));
   }
 
-  private QueryBuilderArgs pareOptions(String cmdLineArgs) throws IOException {
+  private QueryBuilderArgs parseOptions(String cmdLineArgs) throws IOException {
     JdbcExportPipelineOptions opts = commandLineToOptions(cmdLineArgs);
     return JdbcExportArgsFactory.createQueryArgs(opts);
   }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderTest.java
@@ -46,26 +46,10 @@ public class QueryBuilderTest {
   }
 
   @Test
-  public void testCtorCopyEquals() {
-    QueryBuilder q1 = QueryBuilder.fromSqlQuery("SELECT * FROM t1");
-    QueryBuilder copy = q1.copy();
-
-    Assert.assertEquals(q1, copy);
-  }
-
-  @Test
-  public void testCtorCopyContentEquals() {
-    QueryBuilder q1 = QueryBuilder.fromSqlQuery("SELECT * FROM t1");
-    QueryBuilder copy = q1.copy();
-
-    Assert.assertEquals(q1.build(), copy.build());
-  }
-
-  @Test
   public void testCtorCopyWithConditionNotEquals() {
     QueryBuilder q1 = QueryBuilder.fromSqlQuery("SELECT * FROM t1");
-    QueryBuilder copy = q1.copy();
-    copy.withPartitionCondition("pary", "20180101", "20180201");
+    QueryBuilder copy = q1
+        .withPartitionCondition("pary", "20180101", "20180201");
 
     Assert.assertNotEquals(q1.build(), copy.build());
   }
@@ -73,8 +57,7 @@ public class QueryBuilderTest {
   @Test
   public void testCtorCopyWithLimitNotEquals() {
     QueryBuilder q1 = QueryBuilder.fromSqlQuery("SELECT * FROM t1");
-    QueryBuilder copy = q1.copy();
-    copy.withLimit(3L);
+    QueryBuilder copy = q1.withLimit(3L);
 
     Assert.assertNotEquals(q1.build(), copy.build());
   }
@@ -90,8 +73,7 @@ public class QueryBuilderTest {
 
   @Test
   public void testRawSqlWithLimit() {
-    QueryBuilder wrapper = QueryBuilder.fromSqlQuery("SELECT * FROM t1");
-    wrapper.withLimit(102L);
+    QueryBuilder wrapper = QueryBuilder.fromSqlQuery("SELECT * FROM t1").withLimit(102L);
 
     String expected = "SELECT * FROM (SELECT * FROM t1) as user_sql_query WHERE 1=1 LIMIT 102";
 
@@ -100,8 +82,8 @@ public class QueryBuilderTest {
 
   @Test
   public void testRawSqlwithParallelization() {
-    QueryBuilder wrapper = QueryBuilder.fromSqlQuery("SELECT * FROM t1");
-    wrapper.withParallelizationCondition("bucket", 10, 20, true);
+    QueryBuilder wrapper = QueryBuilder.fromSqlQuery("SELECT * FROM t1")
+        .withParallelizationCondition("bucket", 10, 20, true);
 
     String expected =
         "SELECT * FROM (SELECT * FROM t1) as user_sql_query"
@@ -112,8 +94,8 @@ public class QueryBuilderTest {
 
   @Test
   public void testRawSqlWithPartition() {
-    QueryBuilder wrapper = QueryBuilder.fromSqlQuery("SELECT * FROM t1");
-    wrapper.withPartitionCondition("birthDate", "2018-01-01", "2018-02-01");
+    QueryBuilder wrapper = QueryBuilder.fromSqlQuery("SELECT * FROM t1")
+        .withPartitionCondition("birthDate", "2018-01-01", "2018-02-01");
 
     String expected =
         "SELECT * FROM (SELECT * FROM t1) as user_sql_query WHERE 1=1"

--- a/dbeam-core/src/test/java/com/spotify/dbeam/jobs/PsqlReplicationCheckTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/jobs/PsqlReplicationCheckTest.java
@@ -134,6 +134,26 @@ public class PsqlReplicationCheckTest {
         PsqlReplicationCheck.isReplicationDelayed(partition, lastReplication, partitionPeriod));
   }
 
+  @Test
+  public void shouldBeDelayedWithHourlyPartitionPeriod() {
+    Instant partition = Instant.parse("2027-07-31T00:00:00Z");
+    Instant lastReplication = Instant.parse("2027-07-31T00:59:59Z");
+    Duration partitionPeriod = Duration.ofHours(1);
+
+    Assert.assertTrue(
+        PsqlReplicationCheck.isReplicationDelayed(partition, lastReplication, partitionPeriod));
+  }
+
+  @Test
+  public void shouldBeNotDelayedWithHourlyPartitionPeriod() {
+    Instant partition = Instant.parse("2027-07-31T00:00:00Z");
+    Instant lastReplication = Instant.parse("2027-07-31T00:59:59Z");
+    Duration partitionPeriod = Duration.ofHours(1);
+
+    Assert.assertTrue(
+        PsqlReplicationCheck.isReplicationDelayed(partition, lastReplication, partitionPeriod));
+  }
+
   @Test(expected = NotReadyException.class)
   public void shouldRunQueryAndReturnReplicationDelayed() throws Exception {
     String query =


### PR DESCRIPTION
Note that we have to use Period for Monthly exports and Duration for Hourly exports.

> The main distinction between the two classes is that Period uses date-based values, while Duration uses time-based values.

https://www.baeldung.com/java-period-duration
https://stackoverflow.com/questions/41123166/subtleties-between-java-period-and-duration

This PR also makes QueryBuilder immutable and fix a deprecation warning on MySQL driver.