### PR TITLE
Support for non-default database schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ com.spotify.dbeam.options.DBeamPipelineOptions:
     A path to a file containing a SQL query (used instead of --table parameter).
   --table=<String>
     The database table to query and perform the export.
+  --dbSchema=<String>
+    The database schema where the input table is located (use with --table, optional).
   --username=<String>
     Default: dbeam-extractor
     The database user name used by JDBC to authenticate.

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/QueryBuilder.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/QueryBuilder.java
@@ -49,30 +49,36 @@ class QueryBuilder implements Serializable {
   private static class TableQueryBase implements QueryBase {
 
     private final String tableName;
+    private final String dbSchemaName;
     private final String selectClause;
 
-    public TableQueryBase(final String tableName) {
-      this(tableName, DEFAULT_SELECT_CLAUSE);
+    public TableQueryBase(final String dbSchemaName, final String tableName) {
+      this(dbSchemaName, tableName, DEFAULT_SELECT_CLAUSE);
     }
 
-    public TableQueryBase(final String tableName, final String selectClause) {
+    public TableQueryBase(final String dbSchemaName, final String tableName,
+                          final String selectClause) {
       this.tableName = tableName;
       this.selectClause = selectClause;
+      this.dbSchemaName = dbSchemaName;
     }
 
     @Override
     public String getBaseSql() {
-      return String.format("%s FROM %s %s", selectClause, tableName, DEFAULT_WHERE_CLAUSE);
+      final String dbSchema = dbSchemaName == null ? "" : (dbSchemaName + ".");
+
+      return String.format("%s FROM %s%s %s", selectClause, dbSchema, tableName,
+              DEFAULT_WHERE_CLAUSE);
     }
 
     @Override
     public TableQueryBase withSelect(final String selectClause) {
-      return new TableQueryBase(this.tableName, selectClause);
+      return new TableQueryBase(this.dbSchemaName, this.tableName, selectClause);
     }
 
     @Override
     public int hashCode() {
-      return tableName.hashCode();
+      return (dbSchemaName + tableName).hashCode();
     }
   }
 
@@ -129,8 +135,13 @@ class QueryBuilder implements Serializable {
     this.limitStr = limitStr;
   }
 
+
   public static QueryBuilder fromTablename(final String tableName) {
-    return new QueryBuilder(new TableQueryBase(tableName));
+    return new QueryBuilder(new TableQueryBase(null,tableName));
+  }
+
+  public static QueryBuilder fromTablename(final String dbSchemaName, final String tableName) {
+    return new QueryBuilder(new TableQueryBase(dbSchemaName,tableName));
   }
 
   public static QueryBuilder fromSqlQuery(final String sqlQuery) {

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/QueryBuilderArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/QueryBuilderArgs.java
@@ -87,19 +87,32 @@ public abstract class QueryBuilderArgs implements Serializable {
     public abstract QueryBuilderArgs build();
   }
 
-  private static Boolean checkTableName(final String tableName) {
-    return tableName.matches("^[a-zA-Z_][a-zA-Z0-9_]*$");
+  private static Boolean checkIfValidDatabaseObjectName(final String objectName) {
+    return objectName.matches("^[a-zA-Z_][a-zA-Z0-9_]*$");
   }
+
+  private static Boolean checkSchemaName(final String dbSchemaName) {
+    return dbSchemaName == null || dbSchemaName.matches("^[a-zA-Z_][a-zA-Z0-9_]*$");
+  }
+
 
   private static Builder createBuilder() {
     return new AutoValue_QueryBuilderArgs.Builder().setPartitionPeriod(Period.ofDays(1));
   }
 
   public static QueryBuilderArgs create(final String tableName) {
-    checkArgument(tableName != null, "TableName cannot be null");
-    checkArgument(checkTableName(tableName), "'table' must follow [a-zA-Z_][a-zA-Z0-9_]*");
+    return create(null,tableName);
+  }
 
-    return createBuilder().setBaseSqlQuery(QueryBuilder.fromTablename(tableName)).build();
+  public static QueryBuilderArgs create(final String dbSchemaName, final String tableName) {
+    checkArgument(tableName != null, "TableName cannot be null");
+    checkArgument(checkIfValidDatabaseObjectName(tableName),
+            "'table' must follow [a-zA-Z_][a-zA-Z0-9_]*");
+    checkArgument(checkSchemaName(dbSchemaName),
+            "'table' must follow [a-zA-Z_][a-zA-Z0-9_]*");
+
+    return createBuilder().setBaseSqlQuery(
+            QueryBuilder.fromTablename(dbSchemaName,tableName)).build();
   }
 
   public static QueryBuilderArgs createFromQuery(final String sqlQuery) {

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/QueryBuilderArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/QueryBuilderArgs.java
@@ -109,7 +109,7 @@ public abstract class QueryBuilderArgs implements Serializable {
     checkArgument(checkIfValidDatabaseObjectName(tableName),
             "'table' must follow [a-zA-Z_][a-zA-Z0-9_]*");
     checkArgument(checkSchemaName(dbSchemaName),
-            "'table' must follow [a-zA-Z_][a-zA-Z0-9_]*");
+            "'dbSchema' must follow [a-zA-Z_][a-zA-Z0-9_]*");
 
     return createBuilder().setBaseSqlQuery(
             QueryBuilder.fromTablename(dbSchemaName,tableName)).build();

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/DBeamPipelineOptions.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/DBeamPipelineOptions.java
@@ -37,6 +37,11 @@ public interface DBeamPipelineOptions extends PipelineOptions {
 
   void setTable(String value);
 
+  @Description("The database schema where the input table is located (use with --table, optional).")
+  String getDbSchema();
+
+  void setDbSchema(String value);
+
   @Description("A path to a file containing a SQL query (used instead of --table parameter).")
   String getSqlFile();
 

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
@@ -154,7 +154,7 @@ public class JdbcExportArgsFactory {
     if (options.getSqlFile() != null) {
       return QueryBuilderArgs.createFromQuery(BeamHelper.readFromFile(options.getSqlFile()));
     } else {
-      return QueryBuilderArgs.create(options.getTable());
+      return QueryBuilderArgs.create(options.getDbSchema(), options.getTable());
     }
   }
 

--- a/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderTest.java
@@ -37,6 +37,15 @@ public class QueryBuilderTest {
   }
 
   @Test
+  public void testCtorFromSchemaAndTable() {
+    QueryBuilder wrapper = QueryBuilder.fromTablename("public","abc");
+
+    String expected = "SELECT * FROM public.abc WHERE 1=1";
+
+    Assert.assertEquals(expected, wrapper.build());
+  }
+
+  @Test
   public void testCtorRawSqlWithoutWhere() {
     QueryBuilder wrapper = QueryBuilder.fromSqlQuery("SELECT * FROM t1");
 

--- a/e2e/ddl.sql
+++ b/e2e/ddl.sql
@@ -33,3 +33,10 @@ FROM
   ;
 ANALYZE demo_table;
 EXPLAIN ANALYZE SELECT * FROM demo_table;
+
+CREATE SCHEMA IF NOT EXISTS test_schema;
+DROP TABLE IF EXISTS test_schema.schema_demo_table;
+CREATE UNLOGGED TABLE test_schema.schema_demo_table
+AS
+SELECT 1::integer foo, 'bar'::text bar;
+EXPLAIN ANALYZE SELECT * FROM test_schema.schema_demo_table;

--- a/e2e/ddl.sql
+++ b/e2e/ddl.sql
@@ -35,8 +35,8 @@ ANALYZE demo_table;
 EXPLAIN ANALYZE SELECT * FROM demo_table;
 
 CREATE SCHEMA IF NOT EXISTS test_schema;
-DROP TABLE IF EXISTS test_schema.schema_demo_table;
-CREATE UNLOGGED TABLE test_schema.schema_demo_table
+DROP TABLE IF EXISTS test_schema.demo_table;
+CREATE UNLOGGED TABLE test_schema.demo_table
 AS
 SELECT 1::integer foo, 'bar'::text bar;
-EXPLAIN ANALYZE SELECT * FROM test_schema.schema_demo_table;
+EXPLAIN ANALYZE SELECT * FROM test_schema.demo_table;

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -90,6 +90,8 @@ runSuite() {
   BINARY_TRANSFER='false' runDBeamDockerCon --executions=3 --avroCodec=deflate1
   BINARY_TRANSFER='false' runDBeamDockerCon --executions=3 --avroCodec=zstandard1
   BINARY_TRANSFER='false' runDBeamDockerCon --executions=3 --avroCodec=deflate1 --queryParallelism=5 --splitColumn=row_number
+  table=schema_demo_table
+  BINARY_TRANSFER='false' runDBeamDockerCon --dbSchema=test_schema --executions=3 --avroCodec=deflate1
 }
 
 light() {

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -90,7 +90,6 @@ runSuite() {
   BINARY_TRANSFER='false' runDBeamDockerCon --executions=3 --avroCodec=deflate1
   BINARY_TRANSFER='false' runDBeamDockerCon --executions=3 --avroCodec=zstandard1
   BINARY_TRANSFER='false' runDBeamDockerCon --executions=3 --avroCodec=deflate1 --queryParallelism=5 --splitColumn=row_number
-  table=schema_demo_table
   BINARY_TRANSFER='false' runDBeamDockerCon --dbSchema=test_schema --executions=3 --avroCodec=deflate1
 }
 


### PR DESCRIPTION
Since most of the databases support different database schemas, we need some easy way to add database schema in addition to table names. `-dbSchema` will just do what you expect, add `schemaname.` prefix to `tableName` in SELECT statements if present, otherwise does nothing.