### PR TITLE
Add option to store only the avro files, without metadata/metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ com.spotify.dbeam.options.OutputOptions:
 
   --output=<String>
     The path for storing the output.
+  --dataOnly=<Boolean>
+    Store only the data files in output folder, skip queries, metrics and metadata files.
 
 com.spotify.dbeam.options.JdbcExportPipelineOptions:
     Configures the DBeam SQL export

--- a/dbeam-core/src/main/java/com/spotify/dbeam/jobs/JdbcAvroJob.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/jobs/JdbcAvroJob.java
@@ -111,10 +111,12 @@ public class JdbcAvroJob {
       JobNameConfiguration.configureJobName(
           pipeline.getOptions(), connection.getCatalog(), tableName);
     }
-    BeamHelper.saveStringOnSubPath(output, "/_AVRO_SCHEMA.avsc", generatedSchema.toString(true));
-    for (int i = 0; i < queries.size(); i++) {
-      BeamHelper.saveStringOnSubPath(
-          output, String.format("/_queries/query_%d.sql", i), queries.get(i));
+    if (!pipelineOptions.as(OutputOptions.class).getDataOnly()) {
+      BeamHelper.saveStringOnSubPath(output, "/_AVRO_SCHEMA.avsc", generatedSchema.toString(true));
+      for (int i = 0; i < queries.size(); i++) {
+        BeamHelper.saveStringOnSubPath(
+                output, String.format("/_queries/query_%d.sql", i), queries.get(i));
+      }
     }
     LOGGER.info("Running queries: {}", queries.toString());
 
@@ -157,7 +159,10 @@ public class JdbcAvroJob {
   public PipelineResult runExport() throws Exception {
     prepareExport();
     final PipelineResult pipelineResult = runAndWait();
-    BeamHelper.saveMetrics(MetricsHelper.getMetrics(pipelineResult), output);
+    if (!pipelineOptions.as(OutputOptions.class).getDataOnly()) {
+      BeamHelper.saveMetrics(MetricsHelper.getMetrics(pipelineResult), output);
+    }
+
     return pipelineResult;
   }
 

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/OutputOptions.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/OutputOptions.java
@@ -20,6 +20,7 @@
 
 package com.spotify.dbeam.options;
 
+import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.Validation;
@@ -31,4 +32,12 @@ public interface OutputOptions extends PipelineOptions {
   String getOutput();
 
   void setOutput(String value);
+
+  @Default.Boolean(false)
+  @Description("Store only the data files in output folder, skip queries,"
+          + " metrics and metadata files.")
+  Boolean getDataOnly();
+
+  void setDataOnly(Boolean value);
+
 }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/args/JdbcExportOptionsTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/args/JdbcExportOptionsTest.java
@@ -20,8 +20,10 @@
 
 package com.spotify.dbeam.args;
 
+import com.spotify.dbeam.jobs.JdbcAvroJob;
 import com.spotify.dbeam.options.JdbcExportArgsFactory;
 import com.spotify.dbeam.options.JdbcExportPipelineOptions;
+import com.spotify.dbeam.options.OutputOptions;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -225,6 +227,26 @@ public class JdbcExportOptionsTest {
                 + "--password=secret --avroSchemaNamespace=ns");
 
     Assert.assertEquals("ns", options.avroSchemaNamespace());
+  }
+  
+  @Test
+  public void shouldConfigureOutputDataOnly() throws IOException, ClassNotFoundException {
+    PipelineOptions defaultDataOnlyoptions =
+        JdbcAvroJob.buildPipelineOptions(new String[] {
+            "--connectionUrl=jdbc:postgresql://some_db",
+            "--table=some_table",
+            "--password=secret"});
+
+    Assert.assertEquals(false, defaultDataOnlyoptions.as(OutputOptions.class).getDataOnly());
+
+    PipelineOptions options =
+        JdbcAvroJob.buildPipelineOptions(new String[] {
+            "--connectionUrl=jdbc:postgresql://some_db",
+            "--table=some_table",
+            "--password=secret",
+            "--dataOnly=true"});
+
+    Assert.assertEquals(true, options.as(OutputOptions.class).getDataOnly());
   }
 
   @Test

--- a/dbeam-core/src/test/java/com/spotify/dbeam/jobs/JdbcAvroJobTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/jobs/JdbcAvroJobTest.java
@@ -113,6 +113,32 @@ public class JdbcAvroJobTest {
     assertThat(records, hasSize(2));
   }
 
+
+  @Test
+  public void shouldRunJdbcAvroJobDataOnly() throws IOException {
+    Path outputPath = testDir.resolve("shouldRunJdbcAvroJobDataOnly");
+
+    JdbcAvroJob.main(
+        new String[] {
+          "--targetParallelism=1", // no need for more threads when testing
+          "--partition=2025-02-28",
+          "--skipPartitionCheck",
+          "--dataOnly=true",
+          "--exportTimeout=PT1M",
+          "--connectionUrl=" + CONNECTION_URL,
+          "--username=",
+          "--passwordFile=" + passwordPath.toString(),
+          "--table=COFFEES",
+          "--output=" + outputPath.toString(),
+          "--avroCodec=zstandard1"
+        });
+
+    assertThat(
+            TestHelper.listDir(outputPath.toFile()),
+            containsInAnyOrder(
+                    "part-00000-of-00001.avro"));
+  }
+
   @Test
   public void shouldRunJdbcAvroJobSqlFile() throws IOException {
     Path outputPath = testDir.resolve("shouldRunJdbcAvroJobSqlFile");


### PR DESCRIPTION
On Redshift `COPY` and External Tables require clean S3 folders where only the avro datafiles are stored. Currently, we have to delete all metadata/metrics files after the job runs to make them available on Redshift. 

With this patch, we can use `--dataOnly` to store only the avro files and make our dumb redshift happy.