### PR TITLE
Pass Avro schema name to the job

### DIFF
--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,6 +37,8 @@ public abstract class JdbcExportArgs implements Serializable {
 
   public abstract String avroSchemaNamespace();
 
+  public abstract Optional<String> avroSchemaName();
+
   public abstract Optional<String> avroDoc();
 
   public abstract Boolean useAvroLogicalTypes();
@@ -53,6 +55,8 @@ public abstract class JdbcExportArgs implements Serializable {
     abstract Builder setQueryBuilderArgs(QueryBuilderArgs queryBuilderArgs);
 
     abstract Builder setAvroSchemaNamespace(String avroSchemaNamespace);
+
+    abstract Builder setAvroSchemaName(Optional<String> avroSchemaName);
 
     abstract Builder setAvroDoc(Optional<String> avroDoc);
 
@@ -73,6 +77,7 @@ public abstract class JdbcExportArgs implements Serializable {
         queryBuilderArgs,
         "dbeam_generated",
         Optional.empty(),
+        Optional.empty(),
         false,
         Duration.ofDays(7),
         Optional.empty());
@@ -82,6 +87,7 @@ public abstract class JdbcExportArgs implements Serializable {
       final JdbcAvroArgs jdbcAvroArgs,
       final QueryBuilderArgs queryBuilderArgs,
       final String avroSchemaNamespace,
+      final Optional<String> avroSchemaName,
       final Optional<String> avroDoc,
       final Boolean useAvroLogicalTypes,
       final Duration exportTimeout,
@@ -90,6 +96,7 @@ public abstract class JdbcExportArgs implements Serializable {
         .setJdbcAvroOptions(jdbcAvroArgs)
         .setQueryBuilderArgs(queryBuilderArgs)
         .setAvroSchemaNamespace(avroSchemaNamespace)
+        .setAvroSchemaName(avroSchemaName)
         .setAvroDoc(avroDoc)
         .setUseAvroLogicalTypes(useAvroLogicalTypes)
         .setExportTimeout(exportTimeout)

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/BeamJdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/BeamJdbcAvroSchema.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -76,10 +76,12 @@ public class BeamJdbcAvroSchema {
     final String avroDoc =
         args.avroDoc()
             .orElseGet(() -> String.format("Generate schema from JDBC ResultSet from %s", dbUrl));
+    Optional<String> maybeSchemaName = args.avroSchemaName();
     return JdbcAvroSchema.createSchemaByReadingOneRow(
         connection,
         args.queryBuilderArgs(),
         args.avroSchemaNamespace(),
+        maybeSchemaName,
         avroDoc,
         args.useAvroLogicalTypes());
   }

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -74,6 +74,7 @@ public class JdbcExportArgsFactory {
         jdbcAvroArgs,
         createQueryArgs(exportOptions),
         exportOptions.getAvroSchemaNamespace(),
+        Optional.ofNullable(exportOptions.getAvroSchemaName()),
         Optional.ofNullable(exportOptions.getAvroDoc()),
         exportOptions.isUseAvroLogicalTypes(),
         Duration.parse(exportOptions.getExportTimeout()),

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -70,6 +70,11 @@ public interface JdbcExportPipelineOptions extends DBeamPipelineOptions {
   String getAvroSchemaNamespace();
 
   void setAvroSchemaNamespace(String value);
+
+  @Description("The name of the generated avro schema. By default it uses the table name.")
+  String getAvroSchemaName();
+
+  void setAvroSchemaName(String value);
 
   @Description("The top-level record doc string of the generated avro schema.")
   String getAvroDoc();

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -64,6 +64,7 @@ public class JdbcAvroRecordTest {
             DbTestHelper.createConnection(CONNECTION_URL),
             QueryBuilderArgs.create("COFFEES"),
             "dbeam_generated",
+            Optional.empty(),
             "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test",
             false);
 
@@ -129,6 +130,7 @@ public class JdbcAvroRecordTest {
             DbTestHelper.createConnection(CONNECTION_URL),
             QueryBuilderArgs.create("COFFEES"),
             "dbeam_generated",
+            Optional.empty(),
             "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test",
             true);
 
@@ -146,7 +148,8 @@ public class JdbcAvroRecordTest {
             .createStatement()
             .executeQuery("SELECT * FROM COFFEES");
     Schema schema =
-        JdbcAvroSchema.createAvroSchema(rs, "dbeam_generated", "connection", "doc", false);
+        JdbcAvroSchema.createAvroSchema(
+            rs, "dbeam_generated", "connection", Optional.empty(), "doc", false);
     JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(rs);
     DataFileWriter<GenericRecord> dataFileWriter =
         new DataFileWriter<>(new GenericDatumWriter<>(schema));

--- a/dbeam-core/src/test/java/com/spotify/dbeam/jobs/PsqlReplicationCheckTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/jobs/PsqlReplicationCheckTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,6 +41,7 @@ public class PsqlReplicationCheckTest {
         JdbcAvroArgs.create(JdbcConnectionArgs.create(url)),
         queryBuilderArgs,
         "dbeam_generated",
+        Optional.empty(),
         Optional.empty(),
         false,
         Duration.ZERO,


### PR DESCRIPTION
We want to generate java classes from the avro schemas and we'd like the schema name to be camel case.