### PR TITLE
Fix table name returned for CASTed columns

### DIFF
--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
@@ -110,12 +110,16 @@ public class JdbcAvroSchema {
     return createAvroFields(meta, builder, useLogicalTypes).endRecord();
   }
 
-  private static String getDatabaseTableName(final ResultSetMetaData meta) throws SQLException {
-    if (meta.getColumnCount() > 0) {
-      return normalizeForAvro(meta.getTableName(1));
-    } else {
-      return "no_table_name";
+  static String getDatabaseTableName(final ResultSetMetaData meta) throws SQLException {
+    final String defaultTableName = "no_table_name";
+
+    for (int i = 0; i < meta.getColumnCount(); i++) {
+      String metaTableName = meta.getTableName(i + 1);
+      if (metaTableName != null && !metaTableName.isEmpty()) {
+        return normalizeForAvro(metaTableName);
+      }
     }
+    return defaultTableName;
   }
 
   private static SchemaBuilder.FieldAssembler<Schema> createAvroFields(

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
@@ -113,8 +113,8 @@ public class JdbcAvroSchema {
   static String getDatabaseTableName(final ResultSetMetaData meta) throws SQLException {
     final String defaultTableName = "no_table_name";
 
-    for (int i = 0; i < meta.getColumnCount(); i++) {
-      String metaTableName = meta.getTableName(i + 1);
+    for (int i = 1; i <= meta.getColumnCount(); i++) {
+      String metaTableName = meta.getTableName(i);
       if (metaTableName != null && !metaTableName.isEmpty()) {
         return normalizeForAvro(metaTableName);
       }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
@@ -1,0 +1,49 @@
+package com.spotify.dbeam.avro;
+
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class JdbcAvroSchemaTest {
+
+  @Test
+  public void checkTableNameForOrdinaryColumn() throws SQLException {
+    ResultSetMetaData meta = Mockito.mock(ResultSetMetaData.class);
+    when(meta.getColumnCount()).thenReturn(1);
+    when(meta.getTableName(1)).thenReturn("test_table");
+
+    String expected = "test_table";
+    String tableName = JdbcAvroSchema.getTableNameFromMetadata(meta);
+
+    Assert.assertEquals(expected, tableName);
+  }
+
+  @Test
+  public void checkTableNameForCastColumn() throws SQLException {
+    ResultSetMetaData meta = Mockito.mock(ResultSetMetaData.class);
+    when(meta.getColumnCount()).thenReturn(1);
+    when(meta.getTableName(1)).thenReturn("");
+
+    String expected = "no_table_name";
+    String tableName = JdbcAvroSchema.getTableNameFromMetadata(meta);
+
+    Assert.assertEquals(expected, tableName);
+  }
+
+  @Test
+  public void checkTableNameForCastAndOrdinaryColumns() throws SQLException {
+    ResultSetMetaData meta = Mockito.mock(ResultSetMetaData.class);
+    when(meta.getColumnCount()).thenReturn(2);
+    when(meta.getTableName(1)).thenReturn("");
+    when(meta.getTableName(2)).thenReturn("test_table");
+
+    String expected = "test_table";
+    String tableName = JdbcAvroSchema.getTableNameFromMetadata(meta);
+
+    Assert.assertEquals(expected, tableName);
+  }
+}

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
@@ -1,3 +1,23 @@
+/*-
+ * -\-\-
+ * DBeam Core
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
 package com.spotify.dbeam.avro;
 
 import static org.mockito.Mockito.when;
@@ -17,7 +37,7 @@ public class JdbcAvroSchemaTest {
     when(meta.getTableName(1)).thenReturn("test_table");
 
     String expected = "test_table";
-    String tableName = JdbcAvroSchema.getTableNameFromMetadata(meta);
+    String tableName = JdbcAvroSchema.getDatabaseTableName(meta);
 
     Assert.assertEquals(expected, tableName);
   }
@@ -29,7 +49,7 @@ public class JdbcAvroSchemaTest {
     when(meta.getTableName(1)).thenReturn("");
 
     String expected = "no_table_name";
-    String tableName = JdbcAvroSchema.getTableNameFromMetadata(meta);
+    String tableName = JdbcAvroSchema.getDatabaseTableName(meta);
 
     Assert.assertEquals(expected, tableName);
   }
@@ -42,7 +62,7 @@ public class JdbcAvroSchemaTest {
     when(meta.getTableName(2)).thenReturn("test_table");
 
     String expected = "test_table";
-    String tableName = JdbcAvroSchema.getTableNameFromMetadata(meta);
+    String tableName = JdbcAvroSchema.getDatabaseTableName(meta);
 
     Assert.assertEquals(expected, tableName);
   }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
@@ -55,6 +55,18 @@ public class JdbcAvroSchemaTest {
   }
 
   @Test
+  public void checkTableNameForCastColumnNull() throws SQLException {
+    ResultSetMetaData meta = Mockito.mock(ResultSetMetaData.class);
+    when(meta.getColumnCount()).thenReturn(1);
+    when(meta.getTableName(1)).thenReturn(null);
+
+    String expected = "no_table_name";
+    String tableName = JdbcAvroSchema.getDatabaseTableName(meta);
+
+    Assert.assertEquals(expected, tableName);
+  }
+
+  @Test
   public void checkTableNameForCastAndOrdinaryColumns() throws SQLException {
     ResultSetMetaData meta = Mockito.mock(ResultSetMetaData.class);
     when(meta.getColumnCount()).thenReturn(2);


### PR DESCRIPTION
### Problem
As reported by an internal user, when `--sqlFile` parameter is used and one of the columns is CASTed
```
SELECT
  CAST(date_test AS varchar) AS date_str,
```
dbeam throws an exception
```
[main] ERROR com.spotify.dbeam.jobs.ExceptionHandling 
- Failure: org.apache.avro.SchemaParseException: Empty name
at org.apache.avro.Schema.validateName(Schema.java:1525)
at org.apache.avro.Schema.access$400(Schema.java:87)
at org.apache.avro.Schema$Name.<init>(Schema.java:675)
at org.apache.avro.Schema.createRecord(Schema.java:212)
at org.apache.avro.SchemaBuilder$RecordBuilder.fields(SchemaBuilder.java:1805)
at com.spotify.dbeam.avro.JdbcAvroSchema.createAvroSchema(JdbcAvroSchema.java:113)
at com.spotify.dbeam.avro.JdbcAvroSchema.createSchemaByReadingOneRow(JdbcAvroSchema.java:86)
at com.spotify.dbeam.avro.BeamJdbcAvroSchema.generateAvroSchema(BeamJdbcAvroSchema.java:90)
at com.spotify.dbeam.avro.BeamJdbcAvroSchema.getAvroSchema(BeamJdbcAvroSchema.java:77)
at com.spotify.dbeam.avro.BeamJdbcAvroSchema.createSchema(BeamJdbcAvroSchema.java:54)
at com.spotify.dbeam.jobs.JdbcAvroJob.prepareExport(JdbcAvroJob.java:101)
at com.spotify.dbeam.jobs.JdbcAvroJob.runExport(JdbcAvroJob.java:145)
at com.spotify.dbeam.jobs.JdbcAvroJob.main(JdbcAvroJob.java:153)
```

It turned out that ResultSetMetaData.getTableName(...) returns an empty string for CASTed columns (on Postgres), which is not accepted later by `org.apache.avro.Schema`.

### Changes
The change is to either return non-empty value or default one.

Tests:
* "Unit tests are included"
* "I successfully ran my test jobs with this code"

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Ensure code formating (use `mvn com.coveo:fmt-maven-plugin:format org.codehaus.mojo:license-maven-plugin:update-file-header`)
- [ ] Document any relevant additions/changes in the appropriate spot in javadocs/docs/README.