### PR TITLE
Run CI on Java 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java_version: ['11']
+        java_version: ['11', '17']
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Beam SDK 2.37.0 now supports Java 17.