### PR TITLE
Add test for QueryBuilderArgs.sqlQueryWithLimitOne

### DIFF
--- a/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderArgsTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderArgsTest.java
@@ -291,6 +291,19 @@ public class QueryBuilderArgsTest {
         actual.buildQueries(connection));
   }
 
+  @Test
+  public void testSqlQueryWithLimitOne() throws IOException, SQLException {
+    final QueryBuilderArgs actual =
+        parseOptions(
+            String.format(
+                "--connectionUrl=jdbc:postgresql://some_db --sqlFile=%s",
+                coffeesSqlQueryPath.toString()));
+    Assert.assertEquals(
+        "SELECT * FROM (SELECT * FROM COFFEES WHERE SIZE > 10)"
+            + " as user_sql_query WHERE 1=1 LIMIT 1",
+        actual.sqlQueryWithLimitOne());
+  }
+
   private QueryBuilderArgs parseOptions(String cmdLineArgs) throws IOException {
     JdbcExportPipelineOptions opts = commandLineToOptions(cmdLineArgs);
     return JdbcExportArgsFactory.createQueryArgs(opts);


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that `actual.sqlQueryWithLimitOne()` is equal to `"SELECT * FROM (SELECT * FROM COFFEES WHERE SIZE > 10) as user_sql_query WHERE 1=1 LIMIT 1"` when `sqlQueryWithLimitOne` is called.
This tests the method [`QueryBuilderArgs.sqlQueryWithLimitOne`](https://github.com/spotify/dbeam/blob/f10bf0b899d853bfa7085f1306d0730e28989d08/dbeam-core/src/main/java/com/spotify/dbeam/args/QueryBuilderArgs.java#L112).
This test is based on the test [`shouldConfigurePartitionColumnAndLimitForSqlFile`](https://github.com/lacinoire/dbeam/blob/04db604e280098921fe216e7808b7591cba766a2/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderArgsTest.java#L215).

Curious to hear what you think!

Also, is the description I provided of the test helping you to answer to this pull request? Why (not)?

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))

## Checklist for PR author(s)
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Ensure code formating (use `mvn com.coveo:fmt-maven-plugin:format org.codehaus.mojo:license-maven-plugin:update-file-header`)
- [x] Document any relevant additions/changes in the appropriate spot in javadocs/docs/README.
