### PR TITLE
Support SQL column with NOT NULL constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ com.spotify.dbeam.options.JdbcExportPipelineOptions:
   --useAvroLogicalTypes=<Boolean>
     Default: false
     Controls whether generated Avro schema will contain logicalTypes or not.
+  --supportAvroNotNullTypes=<Boolean>
+    Default: false
+    Controls whether generated Avro schema will support not null types.
 ```
 
 #### Input Avro schema file

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
@@ -45,6 +45,8 @@ public abstract class JdbcExportArgs implements Serializable {
 
   public abstract Boolean useAvroLogicalTypes();
 
+  public abstract Boolean useAvroNotNullTypes();
+  
   public abstract Duration exportTimeout();
 
   public abstract Optional<Schema> inputAvroSchema();
@@ -63,6 +65,8 @@ public abstract class JdbcExportArgs implements Serializable {
     abstract Builder setAvroDoc(Optional<String> avroDoc);
 
     abstract Builder setUseAvroLogicalTypes(Boolean useAvroLogicalTypes);
+
+    abstract Builder setUseAvroNotNullTypes(Boolean useAvroNotNullTypes);
 
     abstract Builder setExportTimeout(Duration exportTimeout);
 

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
@@ -85,6 +85,7 @@ public abstract class JdbcExportArgs implements Serializable {
         Optional.empty(),
         Optional.empty(),
         false,
+        false,
         Duration.ofDays(7),
         Optional.empty());
   }
@@ -96,6 +97,7 @@ public abstract class JdbcExportArgs implements Serializable {
       final Optional<String> avroSchemaName,
       final Optional<String> avroDoc,
       final Boolean useAvroLogicalTypes,
+      final Boolean useAvroNotNullTypes,
       final Duration exportTimeout,
       final Optional<Schema> inputAvroSchema) {
     return new AutoValue_JdbcExportArgs.Builder()
@@ -105,6 +107,7 @@ public abstract class JdbcExportArgs implements Serializable {
         .setAvroSchemaName(avroSchemaName)
         .setAvroDoc(avroDoc)
         .setUseAvroLogicalTypes(useAvroLogicalTypes)
+        .setUseAvroNotNullTypes(useAvroNotNullTypes)
         .setExportTimeout(exportTimeout)
         .setInputAvroSchema(inputAvroSchema)
         .build();

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
@@ -46,7 +46,7 @@ public abstract class JdbcExportArgs implements Serializable {
   public abstract Boolean useAvroLogicalTypes();
 
   public abstract Boolean useAvroNotNullTypes();
-  
+
   public abstract Duration exportTimeout();
 
   public abstract Optional<Schema> inputAvroSchema();

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/BeamJdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/BeamJdbcAvroSchema.java
@@ -90,7 +90,8 @@ public class BeamJdbcAvroSchema {
         args.avroSchemaNamespace(),
         args.avroSchemaName(),
         avroDoc,
-        args.useAvroLogicalTypes());
+        args.useAvroLogicalTypes(),
+        args.useAvroNotNullTypes());
   }
 
   public static Optional<Schema> parseOptionalInputAvroSchemaFile(final String filename)

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/BeamJdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/BeamJdbcAvroSchema.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 
 public class BeamJdbcAvroSchema {
 
-  private static Logger LOGGER = LoggerFactory.getLogger(BeamJdbcAvroSchema.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(BeamJdbcAvroSchema.class);
 
   /**
    * Generate Avro schema by reading one row. Expose Beam metrics via a Beam PTransform.

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/FieldTypeHelper.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/FieldTypeHelper.java
@@ -85,7 +85,7 @@ public class FieldTypeHelper {
   public static SchemaBuilder.FieldAssembler<Schema> setDoubleType(
       final SchemaBuilder.FieldTypeBuilder<Schema> field, final boolean useNotNullTypes) {
     return useNotNullTypes
-        ? field.floatType().noDefault()
-        : field.unionOf().nullBuilder().endNull().and().floatType().endUnion().nullDefault();
+        ? field.doubleType().noDefault()
+        : field.unionOf().nullBuilder().endNull().and().doubleType().endUnion().nullDefault();
   }
 }

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/FieldTypeHelper.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/FieldTypeHelper.java
@@ -1,0 +1,91 @@
+/*-
+ * -\-\-
+ * DBeam Core
+ * --
+ * Copyright (C) 2016 - 2023 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.dbeam.avro;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+
+public class FieldTypeHelper {
+  public static SchemaBuilder.FieldAssembler<Schema> setStringType(
+      final SchemaBuilder.FieldTypeBuilder<Schema> field, final boolean useNotNullTypes) {
+    return useNotNullTypes
+        ? field.stringType().noDefault()
+        : field.unionOf().nullBuilder().endNull().and().stringType().endUnion().nullDefault();
+  }
+
+  public static SchemaBuilder.FieldAssembler<Schema> setIntType(
+      final SchemaBuilder.FieldTypeBuilder<Schema> field, final boolean useNotNullTypes) {
+    return useNotNullTypes
+        ? field.intType().noDefault()
+        : field.unionOf().nullBuilder().endNull().and().intType().endUnion().nullDefault();
+  }
+
+  public static SchemaBuilder.FieldAssembler<Schema> setLongType(
+      final SchemaBuilder.FieldTypeBuilder<Schema> field, final boolean useNotNullTypes) {
+    return useNotNullTypes
+        ? field.longType().noDefault()
+        : field.unionOf().nullBuilder().endNull().and().longType().endUnion().nullDefault();
+  }
+
+  public static SchemaBuilder.FieldAssembler<Schema> setLongLogicalType(
+      final SchemaBuilder.FieldTypeBuilder<Schema> field, final boolean useNotNullTypes) {
+    return useNotNullTypes
+        ? field.longBuilder().prop("logicalType", "timestamp-millis").endLong().noDefault()
+        : field
+            .unionOf()
+            .nullBuilder()
+            .endNull()
+            .and()
+            .longBuilder()
+            .prop("logicalType", "timestamp-millis")
+            .endLong()
+            .endUnion()
+            .nullDefault();
+  }
+
+  public static SchemaBuilder.FieldAssembler<Schema> setBytesType(
+      final SchemaBuilder.FieldTypeBuilder<Schema> field, final boolean useNotNullTypes) {
+    return useNotNullTypes
+        ? field.bytesType().noDefault()
+        : field.unionOf().nullBuilder().endNull().and().bytesType().endUnion().nullDefault();
+  }
+
+  public static SchemaBuilder.FieldAssembler<Schema> setBooleanType(
+      final SchemaBuilder.FieldTypeBuilder<Schema> field, final boolean useNotNullTypes) {
+    return useNotNullTypes
+        ? field.booleanType().noDefault()
+        : field.unionOf().nullBuilder().endNull().and().booleanType().endUnion().nullDefault();
+  }
+
+  public static SchemaBuilder.FieldAssembler<Schema> setFloatType(
+      final SchemaBuilder.FieldTypeBuilder<Schema> field, final boolean useNotNullTypes) {
+    return useNotNullTypes
+        ? field.floatType().noDefault()
+        : field.unionOf().nullBuilder().endNull().and().floatType().endUnion().nullDefault();
+  }
+
+  public static SchemaBuilder.FieldAssembler<Schema> setDoubleType(
+      final SchemaBuilder.FieldTypeBuilder<Schema> field, final boolean useNotNullTypes) {
+    return useNotNullTypes
+        ? field.floatType().noDefault()
+        : field.unionOf().nullBuilder().endNull().and().floatType().endUnion().nullDefault();
+  }
+}

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
@@ -163,18 +163,15 @@ public class JdbcAvroSchema {
     return builder;
   }
 
-  public static String getSqlTypeName(int columnType) {
+  public static String getSqlTypeName(final int columnType) {
     return JDBCType.valueOf(columnType).getName();
   }
 
-  private static String getColumnName(ResultSetMetaData meta, int i) throws SQLException {
-    final String columnName;
-    if (meta.getColumnName(i).isEmpty()) {
-      columnName = meta.getColumnLabel(i);
-    } else {
-      columnName = meta.getColumnName(i);
-    }
-    return columnName;
+  private static String getColumnName(final ResultSetMetaData meta, final int columnIndex)
+      throws SQLException {
+    return (meta.getColumnName(columnIndex).isEmpty())
+        ? meta.getColumnLabel(columnIndex)
+        : meta.getColumnName(columnIndex);
   }
 
   private static boolean isNotNullColumn(

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
@@ -149,6 +149,19 @@ public class JdbcAvroSchema {
               .prop("typeName", typeName)
               .prop("columnClassName", columnClassName);
 
+      // new Schema.Field(); // TODO
+      if (isNotNullColumn(meta.isNullable(i))) {
+        final SchemaBuilder.FieldTypeBuilder<Schema>
+                fieldSchemaBuilder2 = field.type().stringType().noDefault();
+        setAvroColumnType(
+                columnType,
+                meta.getPrecision(i),
+                columnClassName,
+                useLogicalTypes,
+                fieldSchemaBuilder2);
+
+      }
+      else {
       final SchemaBuilder.BaseTypeBuilder<
               SchemaBuilder.UnionAccumulator<SchemaBuilder.NullDefault<Schema>>>
           fieldSchemaBuilder = field.type().unionOf().nullBuilder().endNull().and();
@@ -162,8 +175,13 @@ public class JdbcAvroSchema {
               fieldSchemaBuilder);
 
       schemaFieldAssembler.endUnion().nullDefault();
+      }
     }
     return builder;
+  }
+
+  private static boolean isNotNullColumn(final int nullabilityStatus) {
+    final boolean isNullableType = nullabilityStatus == ResultSetMetaData.columnNoNulls;
   }
 
   /**
@@ -178,15 +196,14 @@ public class JdbcAvroSchema {
    * </ul>
    *
    */
-  private static SchemaBuilder.UnionAccumulator<SchemaBuilder.NullDefault<Schema>>
+  private static <R>
+  R
       setAvroColumnType(
           final int columnType,
           final int precision,
           final String columnClassName,
           final boolean useLogicalTypes,
-          final SchemaBuilder.BaseTypeBuilder<
-                  SchemaBuilder.UnionAccumulator<SchemaBuilder.NullDefault<Schema>>>
-              field) {
+          org.apache.avro.SchemaBuilder.BaseTypeBuilder<R> field) {
     switch (columnType) {
       case VARCHAR:
       case CHAR:

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
@@ -175,8 +175,9 @@ public class JdbcAvroSchema {
   }
 
   private static boolean isNotNullColumn(
-      final boolean useNotNullTypes, final int nullabilityStatus) {
-    return useNotNullTypes && (nullabilityStatus == ResultSetMetaData.columnNoNulls);
+      final boolean globalSettingUseNotNullTypes, final int columnNullabilityStatus) {
+    return globalSettingUseNotNullTypes
+        && (columnNullabilityStatus == ResultSetMetaData.columnNoNulls);
   }
 
   /**

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
@@ -20,14 +20,6 @@
 
 package com.spotify.dbeam.avro;
 
-import static com.spotify.dbeam.avro.FieldTypeHelper.setBooleanType;
-import static com.spotify.dbeam.avro.FieldTypeHelper.setBytesType;
-import static com.spotify.dbeam.avro.FieldTypeHelper.setDoubleType;
-import static com.spotify.dbeam.avro.FieldTypeHelper.setFloatType;
-import static com.spotify.dbeam.avro.FieldTypeHelper.setIntType;
-import static com.spotify.dbeam.avro.FieldTypeHelper.setLongLogicalType;
-import static com.spotify.dbeam.avro.FieldTypeHelper.setLongType;
-import static com.spotify.dbeam.avro.FieldTypeHelper.setStringType;
 import static java.sql.Types.ARRAY;
 import static java.sql.Types.BIGINT;
 import static java.sql.Types.BINARY;
@@ -215,50 +207,50 @@ public class JdbcAvroSchema {
       case LONGNVARCHAR:
       case LONGVARCHAR:
       case NCHAR:
-        return setStringType(field, useNotNullTypes);
+        return FieldTypeHelper.setStringType(field, useNotNullTypes);
       case BIGINT:
-        return setLongType(field, useNotNullTypes);
+        return FieldTypeHelper.setLongType(field, useNotNullTypes);
       case INTEGER:
       case SMALLINT:
       case TINYINT:
         if (Long.class.getCanonicalName().equals(columnClassName)) {
-          return setLongType(field, useNotNullTypes);
+          return FieldTypeHelper.setLongType(field, useNotNullTypes);
         } else {
-          return setIntType(field, useNotNullTypes);
+          return FieldTypeHelper.setIntType(field, useNotNullTypes);
         }
       case TIMESTAMP:
       case DATE:
       case TIME:
       case TIME_WITH_TIMEZONE:
         if (useLogicalTypes) {
-          return setLongLogicalType(field, useNotNullTypes);
+          return FieldTypeHelper.setLongLogicalType(field, useNotNullTypes);
         } else {
-          return setLongType(field, useNotNullTypes);
+          return FieldTypeHelper.setLongType(field, useNotNullTypes);
         }
       case BOOLEAN:
-        return setBooleanType(field, useNotNullTypes);
+        return FieldTypeHelper.setBooleanType(field, useNotNullTypes);
       case BIT:
         // Note that bit types can take a param/typemod qualifying its length
         // some further docs:
         // https://www.postgresql.org/docs/8.2/datatype-bit.html
         if (precision <= 1) {
-          return setBooleanType(field, useNotNullTypes);
+          return FieldTypeHelper.setBooleanType(field, useNotNullTypes);
         } else {
-          return setBytesType(field, useNotNullTypes);
+          return FieldTypeHelper.setBytesType(field, useNotNullTypes);
         }
       case BINARY:
       case VARBINARY:
       case LONGVARBINARY:
       case ARRAY:
       case BLOB:
-        return setBytesType(field, useNotNullTypes);
+        return FieldTypeHelper.setBytesType(field, useNotNullTypes);
       case DOUBLE:
-        return setDoubleType(field, useNotNullTypes);
+        return FieldTypeHelper.setDoubleType(field, useNotNullTypes);
       case FLOAT:
       case REAL:
-        return setFloatType(field, useNotNullTypes);
+        return FieldTypeHelper.setFloatType(field, useNotNullTypes);
       default:
-        return setStringType(field, useNotNullTypes);
+        return FieldTypeHelper.setStringType(field, useNotNullTypes);
     }
   }
 

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
@@ -145,7 +145,7 @@ public class JdbcAvroSchema {
       final String columnName = getColumnName(meta, i);
 
       final int columnType = meta.getColumnType(i);
-      final String typeName = JDBCType.valueOf(columnType).getName();
+      final String typeName = getSqlTypeName(columnType);
       final String columnClassName = meta.getColumnClassName(i);
       final SchemaBuilder.FieldBuilder<Schema> field =
           builder
@@ -169,6 +169,10 @@ public class JdbcAvroSchema {
           fieldSchemaBuilder);
     }
     return builder;
+  }
+
+  public static String getSqlTypeName(int columnType) {
+    return JDBCType.valueOf(columnType).getName();
   }
 
   private static String getColumnName(ResultSetMetaData meta, int i) throws SQLException {

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
@@ -77,6 +77,7 @@ public class JdbcExportArgsFactory {
         Optional.ofNullable(exportOptions.getAvroSchemaName()),
         Optional.ofNullable(exportOptions.getAvroDoc()),
         exportOptions.isUseAvroLogicalTypes(),
+        exportOptions.isUseAvroNotNullTypes(),
         Duration.parse(exportOptions.getExportTimeout()),
         BeamJdbcAvroSchema.parseOptionalInputAvroSchemaFile(exportOptions.getAvroSchemaFilePath()));
   }

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
@@ -87,6 +87,10 @@ public interface JdbcExportPipelineOptions extends DBeamPipelineOptions {
 
   void setUseAvroLogicalTypes(Boolean value);
 
+  @Default.Boolean(false)
+  @Description("Controls whether generated Avro schema will contain not null types.")
+  Boolean isUseAvroNotNullTypes();
+
   @Default.Integer(10000)
   @Description("Configures JDBC Statement fetch size.")
   Integer getFetchSize();

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
@@ -91,6 +91,8 @@ public interface JdbcExportPipelineOptions extends DBeamPipelineOptions {
   @Description("Controls whether generated Avro schema will contain not null types.")
   Boolean isUseAvroNotNullTypes();
 
+  void setUseAvroNotNullTypes(Boolean value);
+
   @Default.Integer(10000)
   @Description("Configures JDBC Statement fetch size.")
   Integer getFetchSize();

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
@@ -20,8 +20,6 @@
 
 package com.spotify.dbeam.avro;
 
-import static org.mockito.Mockito.when;
-
 import com.google.common.collect.Lists;
 import com.spotify.dbeam.Coffee;
 import com.spotify.dbeam.DbTestHelper;
@@ -52,7 +50,7 @@ import org.mockito.Mockito;
 
 public class JdbcAvroRecordTest {
 
-  private static String CONNECTION_URL =
+  private static final String CONNECTION_URL =
       "jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1";
 
   @BeforeClass
@@ -225,14 +223,14 @@ public class JdbcAvroRecordTest {
     final int columnNum = 1;
 
     final ResultSetMetaData metadata = Mockito.mock(ResultSetMetaData.class);
-    when(metadata.getColumnType(columnNum)).thenReturn(java.sql.Types.INTEGER);
-    when(metadata.getColumnClassName(columnNum)).thenReturn("java.lang.Long");
+    Mockito.when(metadata.getColumnType(columnNum)).thenReturn(java.sql.Types.INTEGER);
+    Mockito.when(metadata.getColumnClassName(columnNum)).thenReturn("java.lang.Long");
 
     final JdbcAvroRecord.SqlFunction<ResultSet, Object> mapping =
         JdbcAvroRecord.computeMapping(metadata, columnNum);
 
     final ResultSet resultSet = Mockito.mock(ResultSet.class);
-    when(resultSet.getLong(columnNum)).thenReturn(valueUnderTest);
+    Mockito.when(resultSet.getLong(columnNum)).thenReturn(valueUnderTest);
     final Object result = mapping.apply(resultSet);
 
     Assert.assertEquals(Long.class, result.getClass());

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
@@ -70,6 +70,7 @@ public class JdbcAvroRecordTest {
             "dbeam_generated",
             Optional.empty(),
             "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test",
+            false,
             false);
 
     Assert.assertNotNull(actual);
@@ -136,7 +137,8 @@ public class JdbcAvroRecordTest {
             "dbeam_generated",
             Optional.empty(),
             "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test",
-            true);
+            true,
+            false);
 
     Assert.assertEquals(fieldCount, actual.getFields().size());
     Assert.assertEquals(
@@ -153,6 +155,7 @@ public class JdbcAvroRecordTest {
             "dbeam_generated",
             Optional.of("CustomSchemaName"),
             "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test",
+            false,
             false);
 
     Assert.assertEquals("CustomSchemaName", actual.getName());
@@ -167,7 +170,7 @@ public class JdbcAvroRecordTest {
             .executeQuery("SELECT * FROM COFFEES");
     final Schema schema =
         JdbcAvroSchema.createAvroSchema(
-            rs, "dbeam_generated", "connection", Optional.empty(), "doc", false);
+            rs, "dbeam_generated", "connection", Optional.empty(), "doc", false, false);
     final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(rs);
     final DataFileWriter<GenericRecord> dataFileWriter =
         new DataFileWriter<>(new GenericDatumWriter<>(schema));

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
@@ -87,7 +87,8 @@ public class JdbcAvroSchemaTest {
         new TypeMapping(java.sql.Types.SQLXML, Schema.Type.STRING), // default TODO ?
         new TypeMapping(java.sql.Types.REF_CURSOR, Schema.Type.STRING), // default ?
         new TypeMapping(java.sql.Types.TIME_WITH_TIMEZONE, Schema.Type.LONG),
-        new TypeMapping(java.sql.Types.TIMESTAMP_WITH_TIMEZONE, Schema.Type.STRING) // default TODO ?
+        new TypeMapping(
+            java.sql.Types.TIMESTAMP_WITH_TIMEZONE, Schema.Type.STRING) // default TODO ?
       };
 
   public static final int COLUMN_NUM = 1;

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
@@ -20,9 +20,6 @@
 
 package com.spotify.dbeam.avro;
 
-import static com.spotify.dbeam.avro.JdbcAvroSchema.getSqlTypeName;
-import static org.mockito.Mockito.when;
-
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -41,7 +38,7 @@ public class JdbcAvroSchemaTest {
     private final int sqlType;
     private final Schema.Type avroType;
 
-    public TypeMapping(int sqlType, Schema.Type avroType) {
+    public TypeMapping(final int sqlType, final Schema.Type avroType) {
       this.sqlType = sqlType;
       this.avroType = avroType;
     }
@@ -96,8 +93,8 @@ public class JdbcAvroSchemaTest {
   @Test
   public void shouldGetDatabaseTableNameFromMetaData() throws SQLException {
     final ResultSetMetaData meta = Mockito.mock(ResultSetMetaData.class);
-    when(meta.getColumnCount()).thenReturn(1);
-    when(meta.getTableName(1)).thenReturn("test_table");
+    Mockito.when(meta.getColumnCount()).thenReturn(1);
+    Mockito.when(meta.getTableName(1)).thenReturn("test_table");
 
     Assert.assertEquals("test_table", JdbcAvroSchema.getDatabaseTableName(meta));
   }
@@ -105,8 +102,8 @@ public class JdbcAvroSchemaTest {
   @Test
   public void shouldDefaultTableNameWhenMetaDataHasEmptyTableName() throws SQLException {
     final ResultSetMetaData meta = Mockito.mock(ResultSetMetaData.class);
-    when(meta.getColumnCount()).thenReturn(1);
-    when(meta.getTableName(1)).thenReturn("");
+    Mockito.when(meta.getColumnCount()).thenReturn(1);
+    Mockito.when(meta.getTableName(1)).thenReturn("");
 
     Assert.assertEquals("no_table_name", JdbcAvroSchema.getDatabaseTableName(meta));
   }
@@ -114,8 +111,8 @@ public class JdbcAvroSchemaTest {
   @Test
   public void shouldDefaultTableNameWhenMetaDataHasNullTableName() throws SQLException {
     final ResultSetMetaData meta = Mockito.mock(ResultSetMetaData.class);
-    when(meta.getColumnCount()).thenReturn(1);
-    when(meta.getTableName(1)).thenReturn(null);
+    Mockito.when(meta.getColumnCount()).thenReturn(1);
+    Mockito.when(meta.getTableName(1)).thenReturn(null);
 
     Assert.assertEquals("no_table_name", JdbcAvroSchema.getDatabaseTableName(meta));
   }
@@ -123,9 +120,9 @@ public class JdbcAvroSchemaTest {
   @Test
   public void shouldGetDatabaseTableNameFromFirstNonNullMetaData() throws SQLException {
     final ResultSetMetaData meta = Mockito.mock(ResultSetMetaData.class);
-    when(meta.getColumnCount()).thenReturn(2);
-    when(meta.getTableName(1)).thenReturn("");
-    when(meta.getTableName(2)).thenReturn("test_table");
+    Mockito.when(meta.getColumnCount()).thenReturn(2);
+    Mockito.when(meta.getTableName(1)).thenReturn("");
+    Mockito.when(meta.getTableName(2)).thenReturn("test_table");
 
     Assert.assertEquals("test_table", JdbcAvroSchema.getDatabaseTableName(meta));
   }
@@ -170,7 +167,7 @@ public class JdbcAvroSchemaTest {
       String message =
           String.format(
               "Mapping #[%d] SQL [%d][%s] => Avro [%s] failed",
-              i, sqlType, getSqlTypeName(sqlType), expectedAvroType);
+              i, sqlType, JdbcAvroSchema.getSqlTypeName(sqlType), expectedAvroType);
       Assert.assertEquals(message, expectedAvroType, field.schema().getType());
       Assert.assertFalse(field.hasDefaultValue()); // no default value set
     }
@@ -207,7 +204,7 @@ public class JdbcAvroSchemaTest {
   @Test
   public void shouldConvertBitSqlTypeWithPrecision2ToBytes() throws SQLException {
     final ResultSet resultSet = buildMockResultSet(Types.BIT);
-    when(resultSet.getMetaData().getPrecision(COLUMN_NUM)).thenReturn(2);
+    Mockito.when(resultSet.getMetaData().getPrecision(COLUMN_NUM)).thenReturn(2);
 
     final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
 
@@ -217,7 +214,8 @@ public class JdbcAvroSchemaTest {
   @Test
   public void shouldConvertIntegerWithLongColumnClassNameToLong() throws SQLException {
     final ResultSet resultSet = buildMockResultSet(Types.INTEGER);
-    when(resultSet.getMetaData().getColumnClassName(COLUMN_NUM)).thenReturn("java.lang.Long");
+    Mockito.when(resultSet.getMetaData().getColumnClassName(COLUMN_NUM))
+            .thenReturn("java.lang.Long");
 
     final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
 
@@ -250,17 +248,15 @@ public class JdbcAvroSchemaTest {
   private Schema createAvroSchema(
       final ResultSet resultSet, final boolean useLogicalTypes, final boolean useNotNullTypes)
       throws SQLException {
-    Schema avroSchema =
-        JdbcAvroSchema.createAvroSchema(
-            resultSet,
-            "namespace1",
-            "url1",
-            Optional.empty(),
-            "doc1",
-            useLogicalTypes,
-            useNotNullTypes);
 
-    return avroSchema;
+    return JdbcAvroSchema.createAvroSchema(
+        resultSet,
+        "namespace1",
+        "url1",
+        Optional.empty(),
+        "doc1",
+        useLogicalTypes,
+        useNotNullTypes);
   }
 
   private Schema createAvroSchemaForSingleField(
@@ -277,17 +273,17 @@ public class JdbcAvroSchemaTest {
   private ResultSet buildMockResultSetWithNotNull(
       final int inputColumnType, final boolean isNotNull) throws SQLException {
     final ResultSetMetaData meta = Mockito.mock(ResultSetMetaData.class);
-    when(meta.getColumnCount()).thenReturn(COLUMN_NUM);
-    when(meta.getTableName(COLUMN_NUM)).thenReturn("test_table");
-    when(meta.getColumnName(COLUMN_NUM)).thenReturn("column1");
-    when(meta.getColumnType(COLUMN_NUM)).thenReturn(inputColumnType);
-    when(meta.getColumnClassName(COLUMN_NUM)).thenReturn("foobar");
+    Mockito.when(meta.getColumnCount()).thenReturn(COLUMN_NUM);
+    Mockito.when(meta.getTableName(COLUMN_NUM)).thenReturn("test_table");
+    Mockito.when(meta.getColumnName(COLUMN_NUM)).thenReturn("column1");
+    Mockito.when(meta.getColumnType(COLUMN_NUM)).thenReturn(inputColumnType);
+    Mockito.when(meta.getColumnClassName(COLUMN_NUM)).thenReturn("foobar");
     final int isNullableType =
         isNotNull ? ResultSetMetaData.columnNoNulls : ResultSetMetaData.columnNullable;
-    when(meta.isNullable(COLUMN_NUM)).thenReturn(isNullableType);
+    Mockito.when(meta.isNullable(COLUMN_NUM)).thenReturn(isNullableType);
 
     final ResultSet resultSet = Mockito.mock(ResultSet.class);
-    when(resultSet.getMetaData()).thenReturn(meta);
+    Mockito.when(resultSet.getMetaData()).thenReturn(meta);
     return resultSet;
   }
 }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
@@ -89,23 +89,24 @@ public class JdbcAvroSchemaTest {
     final ResultSet resultSet = buildMockResultSetWithNotNull(Types.NCHAR, false);
 
     final Schema avroSchema = createAvroSchema(resultSet, true);
-    final Schema fieldSchema = avroSchema.getField("column1").schema();
+    final Schema.Field field = avroSchema.getField("column1");
 
-    Assert.assertEquals(Schema.Type.UNION, fieldSchema.getType());
+    Assert.assertEquals(Schema.Type.UNION, field.schema().getType());
     Assert.assertEquals(
         Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)),
-        fieldSchema.getTypes());
+        field.schema().getTypes());
+    Assert.assertTrue(field.hasDefaultValue()); // null represented as NullNode()
   }
 
   @Test
   public void shouldConvertNotNullSqlTypeToAvroNotNullType() throws SQLException {
     final ResultSet resultSet = buildMockResultSetWithNotNull(Types.NCHAR, true);
 
-    final Schema avroSchema = createAvroSchema(resultSet, true);
-    final Schema fieldSchema = avroSchema.getField("column1").schema();
+    final Schema avroSchema = createAvroSchema(resultSet, false, true);
+    final Schema.Field field = avroSchema.getField("column1");
 
-    Assert.assertEquals(Schema.Type.STRING, fieldSchema.getType());
-    Assert.assertEquals(Arrays.asList(Schema.create(Schema.Type.STRING)), fieldSchema.getTypes());
+    Assert.assertEquals(Schema.Type.STRING, field.schema().getType());
+    Assert.assertFalse(field.hasDefaultValue()); // no default value set
   }
 
   @Test
@@ -176,9 +177,21 @@ public class JdbcAvroSchemaTest {
 
   private Schema createAvroSchema(final ResultSet resultSet, final boolean useLogicalTypes)
       throws SQLException {
+    return createAvroSchema(resultSet, useLogicalTypes, false);
+  }
+
+  private Schema createAvroSchema(
+      final ResultSet resultSet, final boolean useLogicalTypes, final boolean useNotNullTypes)
+      throws SQLException {
     Schema avroSchema =
         JdbcAvroSchema.createAvroSchema(
-            resultSet, "namespace1", "url1", Optional.empty(), "doc1", useLogicalTypes, false);
+            resultSet,
+            "namespace1",
+            "url1",
+            Optional.empty(),
+            "doc1",
+            useLogicalTypes,
+            useNotNullTypes);
 
     return avroSchema;
   }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
@@ -92,7 +92,9 @@ public class JdbcAvroSchemaTest {
     final Schema fieldSchema = avroSchema.getField("column1").schema();
 
     Assert.assertEquals(Schema.Type.UNION, fieldSchema.getType());
-    Assert.assertEquals(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)), fieldSchema.getTypes());
+    Assert.assertEquals(
+        Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING)),
+        fieldSchema.getTypes());
   }
 
   @Test
@@ -172,15 +174,15 @@ public class JdbcAvroSchemaTest {
     Assert.assertEquals(Schema.Type.STRING, fieldSchema.getType());
   }
 
-  private Schema createAvroSchema(
-          final ResultSet resultSet, final boolean useLogicalTypes) throws SQLException {
+  private Schema createAvroSchema(final ResultSet resultSet, final boolean useLogicalTypes)
+      throws SQLException {
     Schema avroSchema =
-            JdbcAvroSchema.createAvroSchema(
-                    resultSet, "namespace1", "url1", Optional.empty(), "doc1", useLogicalTypes);
+        JdbcAvroSchema.createAvroSchema(
+            resultSet, "namespace1", "url1", Optional.empty(), "doc1", useLogicalTypes, false);
 
     return avroSchema;
   }
-  
+
   private Schema createAvroSchemaForSingleField(
       final ResultSet resultSet, final boolean useLogicalTypes) throws SQLException {
     Schema avroSchema = createAvroSchema(resultSet, useLogicalTypes);
@@ -192,19 +194,20 @@ public class JdbcAvroSchemaTest {
     return buildMockResultSetWithNotNull(inputColumnType, false);
   }
 
-  private ResultSet buildMockResultSetWithNotNull(final int inputColumnType, final boolean isNotNull) throws SQLException {
+  private ResultSet buildMockResultSetWithNotNull(
+      final int inputColumnType, final boolean isNotNull) throws SQLException {
     final ResultSetMetaData meta = Mockito.mock(ResultSetMetaData.class);
     when(meta.getColumnCount()).thenReturn(COLUMN_NUM);
     when(meta.getTableName(COLUMN_NUM)).thenReturn("test_table");
     when(meta.getColumnName(COLUMN_NUM)).thenReturn("column1");
     when(meta.getColumnType(COLUMN_NUM)).thenReturn(inputColumnType);
     when(meta.getColumnClassName(COLUMN_NUM)).thenReturn("foobar");
-    final int isNullableType = isNotNull ? ResultSetMetaData.columnNoNulls : ResultSetMetaData.columnNullable;
+    final int isNullableType =
+        isNotNull ? ResultSetMetaData.columnNoNulls : ResultSetMetaData.columnNullable;
     when(meta.isNullable(COLUMN_NUM)).thenReturn(isNullableType);
 
     final ResultSet resultSet = Mockito.mock(ResultSet.class);
     when(resultSet.getMetaData()).thenReturn(meta);
     return resultSet;
   }
-  
 }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/jobs/PsqlReplicationCheckTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/jobs/PsqlReplicationCheckTest.java
@@ -44,6 +44,7 @@ public class PsqlReplicationCheckTest {
         Optional.empty(),
         Optional.empty(),
         false,
+        false,
         Duration.ZERO,
         Optional.empty());
   }


### PR DESCRIPTION
Creates an Avro schema with a field `type` instead of `[null, type]` for SQL column with `NOT NULL` constrain.
Configurable behaviour.

## Checklist for PR author(s)
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Ensure code formating (use `mvn com.coveo:fmt-maven-plugin:format org.codehaus.mojo:license-maven-plugin:update-file-header`)
- [x] Document any relevant additions/changes in the appropriate spot in javadocs/docs/README.