### PR TITLE
Propagate array item types from SQL to Avro schema

### DIFF
--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroRecord.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroRecord.java
@@ -113,10 +113,7 @@ public class JdbcAvroRecord {
           return resultSet -> nullableBytes(resultSet.getBytes(column));
         }
       case ARRAY:
-        return resultSet -> {
-//          java.sql.Array arr = resultSet.getArray(column);
-          return resultSet.getArray(column);
-        };
+        return resultSet -> resultSet.getArray(column);
       case BINARY:
       case VARBINARY:
       case LONGVARBINARY:

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroRecord.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroRecord.java
@@ -112,10 +112,14 @@ public class JdbcAvroRecord {
         } else {
           return resultSet -> nullableBytes(resultSet.getBytes(column));
         }
+      case ARRAY:
+        return resultSet -> {
+//          java.sql.Array arr = resultSet.getArray(column);
+          return resultSet.getArray(column);
+        };
       case BINARY:
       case VARBINARY:
       case LONGVARBINARY:
-      case ARRAY:
       case BLOB:
         return resultSet -> nullableBytes(resultSet.getBytes(column));
       case DOUBLE:

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroRecordConverter.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroRecordConverter.java
@@ -104,7 +104,8 @@ public class JdbcAvroRecordConverter {
     return ByteBuffer.wrap(out.getBufffer(), 0, out.size());
   }
 
-  private void writeValue(Object value, BinaryEncoder binaryEncoder) throws SQLException, IOException {
+  private void writeValue(Object value, BinaryEncoder binaryEncoder)
+      throws SQLException, IOException {
     if (value instanceof String) {
       binaryEncoder.writeString((String) value);
     } else if (value instanceof Long) {
@@ -121,7 +122,7 @@ public class JdbcAvroRecordConverter {
       binaryEncoder.writeFloat((Float) value);
     } else if (value instanceof java.sql.Array) {
       binaryEncoder.writeArrayStart();
-      Object[] array = (Object[])((java.sql.Array)value).getArray();
+      Object[] array = (Object[]) ((java.sql.Array) value).getArray();
       binaryEncoder.setItemCount(array.length);
       for (Object arrayItem : array) {
         binaryEncoder.startItem();

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroRecordConverter.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroRecordConverter.java
@@ -97,24 +97,38 @@ public class JdbcAvroRecordConverter {
         binaryEncoder.writeNull();
       } else {
         binaryEncoder.writeIndex(1);
-        if (value instanceof String) {
-          binaryEncoder.writeString((String) value);
-        } else if (value instanceof Long) {
-          binaryEncoder.writeLong((Long) value);
-        } else if (value instanceof Integer) {
-          binaryEncoder.writeInt((Integer) value);
-        } else if (value instanceof Boolean) {
-          binaryEncoder.writeBoolean((Boolean) value);
-        } else if (value instanceof ByteBuffer) {
-          binaryEncoder.writeBytes((ByteBuffer) value);
-        } else if (value instanceof Double) {
-          binaryEncoder.writeDouble((Double) value);
-        } else if (value instanceof Float) {
-          binaryEncoder.writeFloat((Float) value);
-        }
+        writeValue(value, binaryEncoder);
       }
     }
     binaryEncoder.flush();
     return ByteBuffer.wrap(out.getBufffer(), 0, out.size());
+  }
+
+  private void writeValue(Object value, BinaryEncoder binaryEncoder) throws SQLException, IOException {
+    if (value instanceof String) {
+      binaryEncoder.writeString((String) value);
+    } else if (value instanceof Long) {
+      binaryEncoder.writeLong((Long) value);
+    } else if (value instanceof Integer) {
+      binaryEncoder.writeInt((Integer) value);
+    } else if (value instanceof Boolean) {
+      binaryEncoder.writeBoolean((Boolean) value);
+    } else if (value instanceof ByteBuffer) {
+      binaryEncoder.writeBytes((ByteBuffer) value);
+    } else if (value instanceof Double) {
+      binaryEncoder.writeDouble((Double) value);
+    } else if (value instanceof Float) {
+      binaryEncoder.writeFloat((Float) value);
+    } else if (value instanceof java.sql.Array) {
+      binaryEncoder.writeArrayStart();
+      Object[] array = (Object[])((java.sql.Array)value).getArray();
+      binaryEncoder.setItemCount(array.length);
+      for (Object arrayItem : array) {
+        binaryEncoder.startItem();
+        writeValue(arrayItem, binaryEncoder);
+      }
+
+      binaryEncoder.writeArrayEnd();
+    }
   }
 }

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
@@ -162,8 +162,8 @@ public class JdbcAvroSchema {
               SchemaBuilder.UnionAccumulator<SchemaBuilder.NullDefault<Schema>>>
           fieldSchemaBuilder = field.type().unionOf().nullBuilder().endNull().and();
 
-      Integer arrayItemType = resultSet.isFirst() && columnType == ARRAY ?
-                                                   resultSet.getArray(i).getBaseType() : null;
+      Integer arrayItemType = resultSet.isFirst() && columnType == ARRAY
+                              ? resultSet.getArray(i).getBaseType() : null;
 
       final SchemaBuilder.UnionAccumulator<SchemaBuilder.NullDefault<Schema>> schemaFieldAssembler =
           setAvroColumnType(

--- a/dbeam-core/src/test/java/com/spotify/dbeam/Coffee.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/Coffee.java
@@ -110,7 +110,7 @@ public abstract class Coffee {
         updated().orElse(null),
         uid(),
         rownum(),
-        String.join(",", intArr().stream().map(x -> (CharSequence)x.toString())::iterator),
+        String.join(",", intArr().stream().map(x -> (CharSequence) x.toString())::iterator),
         String.join("','", textArr()));
   }
 
@@ -156,7 +156,9 @@ public abstract class Coffee {
             add("rock");
             add("scissors");
             add("paper");
-          }});
+          }}
+      );
+
   public static Coffee COFFEE2 =
       create(
           "colombian caffee",
@@ -180,5 +182,6 @@ public abstract class Coffee {
             add("scissors");
             add("paper");
             add("rock");
-          }});
+          }}
+      );
 }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/Coffee.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/Coffee.java
@@ -22,9 +22,12 @@ package com.spotify.dbeam;
 
 import com.google.auto.value.AutoValue;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 // A fictitious DB model to test different SQL types
 @AutoValue
@@ -42,7 +45,9 @@ public abstract class Coffee {
       final java.sql.Timestamp created,
       final Optional<java.sql.Timestamp> updated,
       final UUID uid,
-      final Long rownum) {
+      final Long rownum,
+      final List<Integer> intArr,
+      final List<String> textArr) {
     return new AutoValue_Coffee(
         name,
         supId,
@@ -55,7 +60,9 @@ public abstract class Coffee {
         created,
         updated,
         uid,
-        rownum);
+        rownum,
+        new ArrayList<>(intArr),
+        new ArrayList<>(textArr));
   }
 
   public abstract String name();
@@ -82,10 +89,15 @@ public abstract class Coffee {
 
   public abstract Long rownum();
 
+  public abstract List<Integer> intArr();
+
+  public abstract List<String> textArr();
+
   public String insertStatement() {
     return String.format(
         Locale.ENGLISH,
-        "INSERT INTO COFFEES " + "VALUES ('%s', %s, '%s', %f, %f, %b, %d, %d, '%s', %s, '%s', %d)",
+        "INSERT INTO COFFEES " + "VALUES ('%s', %s, '%s', %f, %f, %b, %d, %d, '%s', %s, '%s', %d,"
+        + " ARRAY [%s], ARRAY ['%s'])",
         name(),
         supId().orElse(null),
         price().toString(),
@@ -97,7 +109,9 @@ public abstract class Coffee {
         created(),
         updated().orElse(null),
         uid(),
-        rownum());
+        rownum(),
+        String.join(",", intArr().stream().map(x -> (CharSequence)x.toString())::iterator),
+        String.join("','", textArr()));
   }
 
   public static String ddl() {
@@ -114,7 +128,9 @@ public abstract class Coffee {
         + "\"CREATED\" TIMESTAMP NOT NULL,"
         + "\"UPDATED\" TIMESTAMP,"
         + "\"UID\" UUID NOT NULL,"
-        + "\"ROWNUM\" BIGINT NOT NULL);";
+        + "\"ROWNUM\" BIGINT NOT NULL,"
+        + "\"INT_ARR\" INTEGER ARRAY NOT NULL,"
+        + "\"TEXT_ARR\" VARCHAR ARRAY NOT NULL);";
   }
 
   public static Coffee COFFEE1 =
@@ -130,7 +146,17 @@ public abstract class Coffee {
           new java.sql.Timestamp(1488300933000L),
           Optional.empty(),
           UUID.fromString("123e4567-e89b-12d3-a456-426655440000"),
-          1L);
+          1L,
+          new ArrayList<Integer>() {{
+            add(5);
+            add(7);
+            add(11);
+          }},
+          new ArrayList<String>() {{
+            add("rock");
+            add("scissors");
+            add("paper");
+          }});
   public static Coffee COFFEE2 =
       create(
           "colombian caffee",
@@ -144,5 +170,15 @@ public abstract class Coffee {
           new java.sql.Timestamp(1488300723000L),
           Optional.empty(),
           UUID.fromString("123e4567-e89b-a456-12d3-426655440000"),
-          2L);
+          2L,
+          new ArrayList<Integer>() {{
+            add(7);
+            add(11);
+            add(23);
+          }},
+          new ArrayList<String>() {{
+            add("scissors");
+            add("paper");
+            add("rock");
+          }});
 }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
@@ -34,6 +34,9 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -42,9 +45,11 @@ import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileReader;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.file.SeekableByteArrayInput;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.Utf8;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -62,7 +67,7 @@ public class JdbcAvroRecordTest {
 
   @Test
   public void shouldCreateSchema() throws ClassNotFoundException, SQLException {
-    final int fieldCount = 12;
+    final int fieldCount = 14;
     final Schema actual =
         JdbcAvroSchema.createSchemaByReadingOneRow(
             DbTestHelper.createConnection(CONNECTION_URL),
@@ -92,7 +97,9 @@ public class JdbcAvroRecordTest {
             "CREATED",
             "UPDATED",
             "UID",
-            "ROWNUM"),
+            "ROWNUM",
+            "INT_ARR",
+            "TEXT_ARR"),
         actual.getFields().stream().map(Schema.Field::name).collect(Collectors.toList()));
     for (Schema.Field f : actual.getFields()) {
       Assert.assertEquals(Schema.Type.UNION, f.schema().getType());
@@ -128,7 +135,7 @@ public class JdbcAvroRecordTest {
 
   @Test
   public void shouldCreateSchemaWithLogicalTypes() throws ClassNotFoundException, SQLException {
-    final int fieldCount = 12;
+    final int fieldCount = 14;
     final Schema actual =
         JdbcAvroSchema.createSchemaByReadingOneRow(
             DbTestHelper.createConnection(CONNECTION_URL),
@@ -163,8 +170,10 @@ public class JdbcAvroRecordTest {
       throws ClassNotFoundException, SQLException, IOException {
     final ResultSet rs =
         DbTestHelper.createConnection(CONNECTION_URL)
-            .createStatement()
+            .createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY)
             .executeQuery("SELECT * FROM COFFEES");
+
+    rs.first();
     final Schema schema =
         JdbcAvroSchema.createAvroSchema(
             rs, "dbeam_generated", "connection", Optional.empty(), "doc", false);
@@ -173,6 +182,7 @@ public class JdbcAvroRecordTest {
         new DataFileWriter<>(new GenericDatumWriter<>(schema));
     final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     dataFileWriter.create(schema, outputStream);
+    rs.previous();
     // convert and write
     while (rs.next()) {
       dataFileWriter.appendEncoded(converter.convertResultSetIntoAvroBytes());
@@ -194,8 +204,11 @@ public class JdbcAvroRecordTest {
             .findFirst()
             .orElseThrow(() -> new IllegalArgumentException("not found"));
 
-    Assert.assertEquals(12, record.getSchema().getFields().size());
+    Assert.assertEquals(14, record.getSchema().getFields().size());
     Assert.assertEquals(schema, record.getSchema());
+    List<String> actualTxtArray =
+        ((GenericData.Array<Utf8>)record.get(13)).stream().map(x -> x.toString()).collect(
+        Collectors.toList());
     final Coffee actual =
         Coffee.create(
             record.get(0).toString(),
@@ -209,7 +222,9 @@ public class JdbcAvroRecordTest {
             new java.sql.Timestamp((Long) record.get(8)),
             Optional.ofNullable((Long) record.get(9)).map(Timestamp::new),
             TestHelper.byteBufferToUuid((ByteBuffer) record.get(10)),
-            (Long) record.get(11));
+            (Long) record.get(11),
+            new ArrayList<>((GenericData.Array<Integer>)record.get(12)),
+            actualTxtArray);
     Assert.assertEquals(Coffee.COFFEE1, actual);
   }
 

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
@@ -207,7 +207,7 @@ public class JdbcAvroRecordTest {
     Assert.assertEquals(14, record.getSchema().getFields().size());
     Assert.assertEquals(schema, record.getSchema());
     List<String> actualTxtArray =
-        ((GenericData.Array<Utf8>)record.get(13)).stream().map(x -> x.toString()).collect(
+        ((GenericData.Array<Utf8>) record.get(13)).stream().map(x -> x.toString()).collect(
         Collectors.toList());
     final Coffee actual =
         Coffee.create(
@@ -223,7 +223,7 @@ public class JdbcAvroRecordTest {
             Optional.ofNullable((Long) record.get(9)).map(Timestamp::new),
             TestHelper.byteBufferToUuid((ByteBuffer) record.get(10)),
             (Long) record.get(11),
-            new ArrayList<>((GenericData.Array<Integer>)record.get(12)),
+            new ArrayList<>((GenericData.Array<Integer>) record.get(12)),
             actualTxtArray);
     Assert.assertEquals(Coffee.COFFEE1, actual);
   }

--- a/docs/type-conversion.md
+++ b/docs/type-conversion.md
@@ -5,31 +5,31 @@ When applicable and `--useAvroLogicalTypes` parameter is set to `true`, Avro log
 
 To represent nullable columns, unions with the Avro NULL type are used.
 
- **Java SQL type** | **Avro type** | **Avro schema annotations** | **Comments**
---- | --- | --- | ---
-BIGINT | long / string | | Depends on a SQL column precision 
-INTEGER | int | |
-SMALLINT | int | |
-TINYINT | int | |
-TIMESTAMP | long |logicalType: time-millis |
-DATE | long | logicalType: time-millis |
-TIME | long | logicalType: time-millis |
-TIME_WITH_TIMEZONE | long  | logicalType: time-millis |
-BOOLEAN | boolean | |
-BIT | boolean / bytes | | Depends on a SQL column precision
-BINARY | bytes | |
-BINARY | bytes | |
-VARBINARY | bytes | |
-LONGVARBINARY | bytes | |
-ARRAY | bytes | |
-BLOB | bytes | |
-DOUBLE | double | |
-FLOAT | float | |
-REAL | float | |
-VARCHAR | string | |
-CHAR | string | |
-CLOB | string | |
-LONGNVARCHAR | string | |
-LONGVARCHAR | string | |
-NCHAR | string | |
-all other Java SQL types | string | |
+| **Java SQL type**        | **Avro type**   | **Avro schema annotations** | **Comments**                          |
+|--------------------------|-----------------|-----------------------------|---------------------------------------|
+| BIGINT                   | long / string   |                             | Depends on a SQL column precision     |
+| INTEGER                  | int             |                             |                                       |
+| SMALLINT                 | int             |                             |                                       |
+| TINYINT                  | int             |                             |                                       |
+| TIMESTAMP                | long            | logicalType: time-millis    |                                       |
+| DATE                     | long            | logicalType: time-millis    |                                       |
+| TIME                     | long            | logicalType: time-millis    |                                       |
+| TIME_WITH_TIMEZONE       | long            | logicalType: time-millis    |                                       |
+| BOOLEAN                  | boolean         |                             |                                       |
+| BIT                      | boolean / bytes |                             | Depends on a SQL column precision     |
+| BINARY                   | bytes           |                             |                                       |
+| BINARY                   | bytes           |                             |                                       |
+| VARBINARY                | bytes           |                             |                                       |
+| LONGVARBINARY            | bytes           |                             |                                       |
+| ARRAY                    | array           |                             | Propagates an array item type as well |
+| BLOB                     | bytes           |                             |                                       |
+| DOUBLE                   | double          |                             |                                       |
+| FLOAT                    | float           |                             |                                       |
+| REAL                     | float           |                             |                                       |
+| VARCHAR                  | string          |                             |                                       |
+| CHAR                     | string          |                             |                                       |
+| CLOB                     | string          |                             |                                       |
+| LONGNVARCHAR             | string          |                             |                                       |
+| LONGVARCHAR              | string          |                             |                                       |
+| NCHAR                    | string          |                             |                                       |
+| all other Java SQL types | string          |                             |                                       |

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -72,8 +72,7 @@ run_docker_dbeam() {
   fi
   time docker run --interactive --rm \
     --net="$DOCKER_NETWORK" \
-    --mount="type=bind,source=$PROJECT_PATH/dbeam-core/target,target=/dbeam" \
-    $OUTPUT_MOUNT_EXP \
+    --mount="type=bind,source=$SCRIPT_PATH,target=$SCRIPT_PATH" \
     --memory=1G \
     --entrypoint=/usr/bin/java \
     "$JAVA_DOCKER_IMAGE" \

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -7,7 +7,6 @@ set -o pipefail
 
 readonly SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 readonly PROJECT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null && pwd)"
-readonly MOUNT_OUTPUT=0
 
 # This file contatins psql views with complex types to validate and troubleshoot dbeam
 
@@ -66,12 +65,9 @@ pack() {
 }
 
 run_docker_dbeam() {
-  OUTPUT_MOUNT_EXP=""
-  if [ "$MOUNT_OUTPUT" -eq 1 ]; then
-    OUTPUT_MOUNT_EXP=--mount="type=bind,source=$SCRIPT_PATH,target=$SCRIPT_PATH"
-  fi
   time docker run --interactive --rm \
     --net="$DOCKER_NETWORK" \
+    --mount="type=bind,source=$PROJECT_PATH/dbeam-core/target,target=/dbeam" \
     --mount="type=bind,source=$SCRIPT_PATH,target=$SCRIPT_PATH" \
     --memory=1G \
     --entrypoint=/usr/bin/java \

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-echo $1
-
 # fail on error
 set -o errexit
 set -o nounset

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echo $1
+
 # fail on error
 set -o errexit
 set -o nounset
@@ -7,6 +9,7 @@ set -o pipefail
 
 readonly SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 readonly PROJECT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null && pwd)"
+readonly MOUNT_OUTPUT=0
 
 # This file contatins psql views with complex types to validate and troubleshoot dbeam
 
@@ -65,9 +68,14 @@ pack() {
 }
 
 run_docker_dbeam() {
+  OUTPUT_MOUNT_EXP=""
+  if [ "$MOUNT_OUTPUT" -eq 1 ]; then
+    OUTPUT_MOUNT_EXP=--mount="type=bind,source=$SCRIPT_PATH,target=$SCRIPT_PATH"
+  fi
   time docker run --interactive --rm \
     --net="$DOCKER_NETWORK" \
     --mount="type=bind,source=$PROJECT_PATH/dbeam-core/target,target=/dbeam" \
+    $OUTPUT_MOUNT_EXP \
     --memory=1G \
     --entrypoint=/usr/bin/java \
     "$JAVA_DOCKER_IMAGE" \


### PR DESCRIPTION
Before the change it generated this:
```
  }, {
    "name" : "arr1",
    "type" : [ "null", {
      "type" : "array"
    } ],
    "doc" : "From sqlType 2003 ARRAY (java.sql.Array)",
    "default" : null,
    "typeName" : "ARRAY",
    "columnClassName" : "java.sql.Array",
    "sqlCode" : "2003",
    "columnName" : "arr1"
  } ],
```
after the change it generetes:
```
  }, {
    "name" : "arr1",
    "type" : [ "null", {
      "type" : "array",
      "items" : "string"
    } ],
    "doc" : "From sqlType 2003 ARRAY (java.sql.Array)",
    "default" : null,
    "typeName" : "ARRAY",
    "columnClassName" : "java.sql.Array",
    "sqlCode" : "2003",
    "columnName" : "arr1"
  } ],
```

* Executed e2e (Postgres) and manually inspected output
* Modified existing unit tests to include typed arrays and assert the correct behavior on in-memory H2 DB

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Ensure code formating (use `mvn com.coveo:fmt-maven-plugin:format org.codehaus.mojo:license-maven-plugin:update-file-header`)
- [ ] Document any relevant additions/changes in the appropriate spot in javadocs/docs/README.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
