### PR TITLE
Change mvn to use HTTPS for git push

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 
   <scm>
     <connection>scm:git:https://github.com/spotify/dbeam.git</connection>
-    <developerConnection>scm:git:git@github.com:spotify/dbeam.git</developerConnection>
+    <developerConnection>scm:git:https://github.com/spotify/dbeam.git</developerConnection>
     <tag>HEAD</tag>
     <url>scm:https://github.com/spotify/dbeam/</url>
   </scm>


### PR DESCRIPTION
Currently when `maven-release-plugin` is trying to push tag to git it fails with:
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-release-plugin:3.1.1:prepare (default-cli) on project dbeam-parent: Unable to commit files
Error:  Provider message:
Error:  The git-push command failed.
Error:  Command output:
Error:  git@github.com: Permission denied (publickey).
Error:  fatal: Could not read from remote repository.
Error:  
Error:  Please make sure you have the correct access rights
Error:  and the repository exists.
```

Changing developerConnection (read/write) to the same as connection (read only) and this is how it is supposed to work:
1. actions/checkout@v4 automatically configures git with the GITHUB_TOKEN
2. Maven release plugin uses the developerConnection URL: scm:git:https://github.com/spotify/dbeam.git
3. Git automatically uses the token because GitHub Actions pre-configures the credential helper to use the workflow's GITHUB_TOKEN for any HTTPS GitHub URLs.

So the credentials are:
  - Username: x-access-token (or the workflow token)
  - Password: The auto-generated GITHUB_TOKEN

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [ ] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [ ] Ensure code formating (use `mvn com.coveo:fmt-maven-plugin:format org.codehaus.mojo:license-maven-plugin:update-file-header`)
- [ ] Document any relevant additions/changes in the appropriate spot in javadocs/docs/README.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
