### PR TITLE
added(feat): New excludeColumns pipeline parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 e2e/results/*
 *.iml
 .java-version
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ e2e/results/*
 *.iml
 .java-version
 .vscode
+e2e/avro-tools.jar

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ com.spotify.dbeam.options.JdbcExportPipelineOptions:
   --nullableArrayItems=<Boolean>
     Default: false
     Controls whether array items should be nullable, ignored if arrayMode is 'bytes'. 
+  --excludeColumns=<String>
+    A comma-separated list of columns to be excluded from the export.
 ```
 
 #### Input Avro schema file

--- a/dbeam-core/pom.xml
+++ b/dbeam-core/pom.xml
@@ -124,4 +124,23 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.auto.value</groupId>
+              <artifactId>auto-value</artifactId>
+              <version>${auto-value.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
@@ -22,9 +22,11 @@ package com.spotify.dbeam.args;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
 import java.sql.Connection;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Optional;
 import org.apache.avro.Schema;
 
@@ -49,6 +51,17 @@ public abstract class JdbcExportArgs implements Serializable {
 
   public abstract Optional<Schema> inputAvroSchema();
 
+  public abstract Optional<ImmutableSet<String>> excludedColumns();
+
+  public static Optional<ImmutableSet<String>> parseExcludedColumns(
+      final Optional<String> rawExcludedColumns) {
+    return rawExcludedColumns.map(
+        s ->
+            Arrays.stream(s.split(","))
+                .map(String::trim)
+                .collect(ImmutableSet.toImmutableSet()));
+  }
+
   @AutoValue.Builder
   abstract static class Builder {
 
@@ -68,6 +81,8 @@ public abstract class JdbcExportArgs implements Serializable {
 
     abstract Builder setInputAvroSchema(Optional<Schema> inputAvroSchema);
 
+    abstract Builder setExcludedColumns(Optional<ImmutableSet<String>> excludedColumns);
+
     abstract JdbcExportArgs build();
   }
 
@@ -82,6 +97,7 @@ public abstract class JdbcExportArgs implements Serializable {
         Optional.empty(),
         false,
         Duration.ofDays(7),
+        Optional.empty(),
         Optional.empty());
   }
 
@@ -93,7 +109,8 @@ public abstract class JdbcExportArgs implements Serializable {
       final Optional<String> avroDoc,
       final Boolean useAvroLogicalTypes,
       final Duration exportTimeout,
-      final Optional<Schema> inputAvroSchema) {
+      final Optional<Schema> inputAvroSchema,
+      final Optional<ImmutableSet<String>> excludedColumns) {
     return new AutoValue_JdbcExportArgs.Builder()
         .setJdbcAvroOptions(jdbcAvroArgs)
         .setQueryBuilderArgs(queryBuilderArgs)
@@ -103,6 +120,7 @@ public abstract class JdbcExportArgs implements Serializable {
         .setUseAvroLogicalTypes(useAvroLogicalTypes)
         .setExportTimeout(exportTimeout)
         .setInputAvroSchema(inputAvroSchema)
+        .setExcludedColumns(excludedColumns)
         .build();
   }
 

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/QueryBuilderArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/QueryBuilderArgs.java
@@ -25,6 +25,7 @@ import static com.spotify.dbeam.args.ParallelQueryBuilder.findInputBounds;
 import static com.spotify.dbeam.args.ParallelQueryBuilder.queriesForBounds;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import java.io.Serializable;
 import java.sql.Connection;
@@ -57,6 +58,8 @@ public abstract class QueryBuilderArgs implements Serializable {
 
   public abstract Optional<Integer> queryParallelism();
 
+  public abstract Optional<ImmutableSet<String>> excludedColumns();
+
   public abstract Builder builder();
 
   @AutoValue.Builder
@@ -85,6 +88,8 @@ public abstract class QueryBuilderArgs implements Serializable {
     public abstract Builder setQueryParallelism(Integer parallelism);
 
     public abstract Builder setQueryParallelism(Optional<Integer> queryParallelism);
+
+    public abstract Builder setExcludedColumns(Optional<ImmutableSet<String>> excludedColumns);
 
     public abstract QueryBuilderArgs build();
   }
@@ -122,6 +127,9 @@ public abstract class QueryBuilderArgs implements Serializable {
    */
   public List<String> buildQueries(final Connection connection) throws SQLException {
     QueryBuilder queryBuilder = this.baseSqlQuery();
+    if (this.excludedColumns().isPresent()) {
+      queryBuilder = queryBuilder.withExcludedColumns(this.excludedColumns());
+    }
     if (this.partitionColumn().isPresent() && this.partition().isPresent()) {
       queryBuilder =
           configurePartitionCondition(

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/QueryBuilderArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/QueryBuilderArgs.java
@@ -127,8 +127,12 @@ public abstract class QueryBuilderArgs implements Serializable {
    */
   public List<String> buildQueries(final Connection connection) throws SQLException {
     QueryBuilder queryBuilder = this.baseSqlQuery();
+    if (this.splitColumn().isPresent()) {
+      queryBuilder = queryBuilder.withSplitColumn(this.splitColumn());
+    }
     if (this.excludedColumns().isPresent()) {
       queryBuilder = queryBuilder.withExcludedColumns(this.excludedColumns());
+      queryBuilder = queryBuilder.resolveSelect(connection);
     }
     if (this.partitionColumn().isPresent() && this.partition().isPresent()) {
       queryBuilder =

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
@@ -171,7 +171,7 @@ public class JdbcAvroSchema {
         columnName = meta.getColumnName(i);
       }
 
-      if (excludedColumns.contains(columnName)) {
+      if (excludedColumns.stream().anyMatch(columnName::equalsIgnoreCase)) {
         continue;
       }
       

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
@@ -81,7 +81,9 @@ public class JdbcExportArgsFactory {
         Optional.ofNullable(exportOptions.getAvroDoc()),
         exportOptions.isUseAvroLogicalTypes(),
         Duration.parse(exportOptions.getExportTimeout()),
-        BeamJdbcAvroSchema.parseOptionalInputAvroSchemaFile(exportOptions.getAvroSchemaFilePath()));
+        BeamJdbcAvroSchema.parseOptionalInputAvroSchemaFile(exportOptions.getAvroSchemaFilePath()),
+        JdbcExportArgs.parseExcludedColumns(
+            Optional.ofNullable(exportOptions.getExcludeColumns())));
   }
 
   public static QueryBuilderArgs createQueryArgs(final JdbcExportPipelineOptions options)
@@ -129,6 +131,9 @@ public class JdbcExportArgsFactory {
         .setPartitionPeriod(partitionPeriod)
         .setSplitColumn(splitColumn)
         .setQueryParallelism(queryParallelism)
+        .setExcludedColumns(
+            JdbcExportArgs.parseExcludedColumns(
+                Optional.ofNullable(options.getExcludeColumns())))
         .build();
   }
 

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
@@ -149,4 +149,9 @@ public interface JdbcExportPipelineOptions extends DBeamPipelineOptions {
   Long getMinRows();
 
   void setMinRows(Long value);
+
+  @Description("A comma-separated list of columns to be excluded from the export.")
+  String getExcludeColumns();
+
+  void setExcludeColumns(String value);
 }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/TestHelper.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/TestHelper.java
@@ -74,6 +74,7 @@ public class TestHelper {
       throws SQLException {
     mockResultSetMeta(meta, columnIdx, Types.ARRAY, columnName, "java.sql.Array",
         columnTypeName);
+    when(resultSet.findColumn(columnName)).thenReturn(columnIdx);
     Array res1;
     if (array1 == null) {
       res1 = null;

--- a/dbeam-core/src/test/java/com/spotify/dbeam/args/JdbcExportOptionsTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/args/JdbcExportOptionsTest.java
@@ -368,4 +368,16 @@ public class JdbcExportOptionsTest {
         "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
             + "--password=secret --queryParallelism=-5 --splitColumn=id");
   }
+
+  @Test
+  public void shouldParseExcludedColumns() throws IOException, ClassNotFoundException {
+    final JdbcExportArgs options =
+        optionsFromArgs(
+            "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
+                + "--password=secret --excludeColumns=col1,col2");
+
+    Assert.assertEquals(
+        Optional.of(com.google.common.collect.ImmutableSet.of("col1", "col2")),
+        options.excludedColumns());
+  }
 }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderTest.java
@@ -210,6 +210,34 @@ public class QueryBuilderTest {
     Assert.assertEquals(expected, actual);
   }
 
+
+  @Test
+  public void testTableNameWithExcludedColumnsShouldStillUseSelectStar() {
+    final com.google.common.collect.ImmutableSet<String> excludedColumns =
+        com.google.common.collect.ImmutableSet.of("col1");
+    final QueryBuilder wrapper =
+        QueryBuilder.fromTablename("some_table")
+            .withExcludedColumns(java.util.Optional.of(excludedColumns));
+
+    final String expected = "SELECT * FROM some_table WHERE 1=1";
+
+    Assert.assertEquals(expected, wrapper.build());
+  }
+
+  @Test
+  public void testRawSqlWithExcludedColumnShouldRemoveColumns() {
+    final com.google.common.collect.ImmutableSet<String> excludedColumns =
+        com.google.common.collect.ImmutableSet.of("col1");
+    final QueryBuilder wrapper =
+        QueryBuilder.fromSqlQuery("SELECT col1, col2 FROM some_table")
+            .withExcludedColumns(java.util.Optional.of(excludedColumns));
+
+    final String expected = 
+        "SELECT * FROM (SELECT col2 FROM some_table) as user_sql_query WHERE 1=1";
+
+    Assert.assertEquals(expected, wrapper.build());
+  }
+
   private void execAndCompare(String rawInput, String expected) {
     final String actual = QueryBuilder.fromSqlQuery(rawInput).build();
 

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
@@ -196,7 +196,7 @@ public class JdbcAvroRecordTest {
     final Schema schema =
         JdbcAvroSchema.createAvroSchema(
             rs, "dbeam_generated", "connection", Optional.empty(), "doc",
-            false, arrayMode, false);
+            false, arrayMode, false, Optional.empty());
     final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(rs, arrayMode, false);
     final DataFileWriter<GenericRecord> dataFileWriter =
         new DataFileWriter<>(new GenericDatumWriter<>(schema));

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
@@ -197,7 +197,8 @@ public class JdbcAvroRecordTest {
         JdbcAvroSchema.createAvroSchema(
             rs, "dbeam_generated", "connection", Optional.empty(), "doc",
             false, arrayMode, false, Optional.empty());
-    final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(rs, arrayMode, false);
+    final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(rs, schema,
+        arrayMode, false);
     final DataFileWriter<GenericRecord> dataFileWriter =
         new DataFileWriter<>(new GenericDatumWriter<>(schema));
     final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/PostgresJdbcAvroTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/PostgresJdbcAvroTest.java
@@ -111,7 +111,7 @@ public class PostgresJdbcAvroTest {
 
     String arrayMode = ArrayHandlingMode.TypedMetaFromFirstRow;
     final Schema schema = JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
-        Optional.empty(), "doc", true, arrayMode, false);
+        Optional.empty(), "doc", true, arrayMode, false, Optional.empty());
     final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(
         resultSet, arrayMode, false);
 
@@ -145,7 +145,7 @@ public class PostgresJdbcAvroTest {
 
     String arrayMode = ArrayHandlingMode.TypedMetaFromFirstRow;
     final Schema schema = JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
-        Optional.empty(), "doc", true, arrayMode, false);
+        Optional.empty(), "doc", true, arrayMode, false, Optional.empty());
     final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(resultSet, arrayMode,
         false);
 
@@ -170,7 +170,8 @@ public class PostgresJdbcAvroTest {
 
     Assert.assertThrows(RuntimeException.class, () -> JdbcAvroSchema.createAvroSchema(resultSet,
         "ns", "conn_url",
-        Optional.empty(), "doc", true, ArrayHandlingMode.TypedMetaFromFirstRow, false));
+        Optional.empty(), "doc", true, ArrayHandlingMode.TypedMetaFromFirstRow, false,
+        Optional.empty()));
   }
 
   @Test
@@ -187,7 +188,7 @@ public class PostgresJdbcAvroTest {
     String arrayMode = ArrayHandlingMode.Bytes;
 
     final Schema schema = JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
-        Optional.empty(), "doc", true, arrayMode, false);
+        Optional.empty(), "doc", true, arrayMode, false, Optional.empty());
     final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(resultSet, arrayMode,
         false);
 
@@ -223,7 +224,7 @@ public class PostgresJdbcAvroTest {
     String arrayMode = ArrayHandlingMode.TypedMetaPostgres;
 
     final Schema schema = JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
-        Optional.empty(), "doc", true, arrayMode, false);
+        Optional.empty(), "doc", true, arrayMode, false, Optional.empty());
     final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(resultSet, arrayMode,
         false);
     GenericRecord[] actualRecords = bytesToGenericRecords(schema,
@@ -264,7 +265,7 @@ public class PostgresJdbcAvroTest {
     boolean nullableArrayItems = true;
 
     final Schema schema = JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
-        Optional.empty(), "doc", true, arrayMode, nullableArrayItems);
+        Optional.empty(), "doc", true, arrayMode, nullableArrayItems, Optional.empty());
     final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(resultSet, arrayMode,
         nullableArrayItems);
     GenericRecord actualRecord = bytesToGenericRecords(schema,
@@ -342,7 +343,7 @@ public class PostgresJdbcAvroTest {
 
     RuntimeException thrown = Assert.assertThrows(RuntimeException.class,
         () -> JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
-            Optional.empty(), "doc", true, arrayMode, nullableArrayItems));
+            Optional.empty(), "doc", true, arrayMode, nullableArrayItems, Optional.empty()));
     Assert.assertEquals("columnName=array_field_text columnTypeName=text should start with '_'",
         thrown.getMessage());
   }
@@ -363,7 +364,7 @@ public class PostgresJdbcAvroTest {
 
     RuntimeException thrown = Assert.assertThrows(RuntimeException.class,
         () -> JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
-            Optional.empty(), "doc", true, arrayMode, nullableArrayItems));
+            Optional.empty(), "doc", true, arrayMode, nullableArrayItems, Optional.empty()));
     Assert.assertEquals(
         "columnName=array_field_text Postgres type 'not_supported' is not supported",
         thrown.getMessage());

--- a/dbeam-core/src/test/java/com/spotify/dbeam/jobs/PsqlReplicationCheckTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/jobs/PsqlReplicationCheckTest.java
@@ -45,6 +45,7 @@ public class PsqlReplicationCheckTest {
         Optional.empty(),
         false,
         Duration.ZERO,
+        Optional.empty(),
         Optional.empty());
   }
 

--- a/dbeam-core/src/test/java/com/spotify/dbeam/options/InputAvroSchemaTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/options/InputAvroSchemaTest.java
@@ -20,7 +20,6 @@
 
 package com.spotify.dbeam.options;
 
-import com.spotify.dbeam.args.QueryBuilderArgs;
 import com.spotify.dbeam.args.QueryBuilderArgsTest;
 import com.spotify.dbeam.avro.BeamJdbcAvroSchema;
 import java.io.File;
@@ -205,15 +204,5 @@ public class InputAvroSchemaTest {
                 + "--partition=2027-07-31");
 
     Assert.assertNull(options.getAvroSchemaFilePath());
-  }
-
-  private QueryBuilderArgs pareOptions(String cmdLineArgs) throws IOException {
-    PipelineOptionsFactory.register(JdbcExportPipelineOptions.class);
-    final JdbcExportPipelineOptions opts =
-        PipelineOptionsFactory.fromArgs(cmdLineArgs.split(" "))
-            .withValidation()
-            .create()
-            .as(JdbcExportPipelineOptions.class);
-    return JdbcExportArgsFactory.createQueryArgs(opts);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,16 @@
         <artifactId>threetenbp</artifactId>
         <version>${threetenbp.version}</version>
       </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>1.17.5</version>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy-agent</artifactId>
+        <version>1.17.5</version>
+      </dependency>
       <!-- from libraries-bom -->
       <dependency>
         <groupId>io.opencensus</groupId>


### PR DESCRIPTION
This PR adds a new parameter named `--exludeColumns` to the pipeline options, which allows users to pass a set of comma separated column names that will be excluded from the final AVRO export. 

## Checklist for PR author(s)
<!-- If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do. -->
- [x] Changes are covered by unit tests (no major decrease in code coverage %) and/or integration tests.
- [x] Ensure code formating (use `mvn com.coveo:fmt-maven-plugin:format org.codehaus.mojo:license-maven-plugin:update-file-header`)
- [x] Document any relevant additions/changes in the appropriate spot in javadocs/docs/README.