### PR TITLE
Bump dependencies, JUnit 5, Java 25, Beam 2.74.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -50,7 +50,7 @@ jobs:
           fail_ci_if_error: false # optional (default = false)
           verbose: true # optional (default = false)
       - name: Install avro tools
-        if: matrix.java_version == '17'
+        if: matrix.java_version == '21'
         run: |
           wget https://dlcdn.apache.org/avro/avro-1.11.5/java/avro-tools-1.11.5.jar
           mkdir -p /opt/avro
@@ -59,12 +59,12 @@ jobs:
           echo "alias avro-tools='java -jar /opt/avro/avro-tools-1.11.5.jar'" > ~/.bashrc
       - name: End to end tests
         shell: bash
-        if: matrix.java_version == '17'
+        if: matrix.java_version == '21'
         run: ./e2e/e2e.sh
       - run: mkdir staging && cp /tmp/debeam_e2e.log ./staging
-        if: matrix.java_version == '17'
+        if: matrix.java_version == '21'
       - uses: actions/upload-artifact@v4
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && matrix.java_version == '17'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && matrix.java_version == '21'
         with:
           name: Package
           path: staging

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java_version: ['11', '17', '21']
+        java_version: ['11', '17', '21', '25']
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -86,12 +86,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.m2
-          key: Linux-java11-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: Linux-java11-m2
-      - name: Set up JDK 11
+          key: Linux-java21-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: Linux-java21-m2
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'adopt'  # use Corretto once supported https://github.com/actions/setup-java/issues/68
       - name: Deploy
         env:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -52,11 +52,11 @@ jobs:
       - name: Install avro tools
         if: matrix.java_version == '17'
         run: |
-          wget https://dlcdn.apache.org/avro/avro-1.11.3/java/avro-tools-1.11.3.jar
+          wget https://dlcdn.apache.org/avro/avro-1.11.5/java/avro-tools-1.11.5.jar
           mkdir -p /opt/avro
-          mv avro-tools-1.11.3.jar /opt/avro/
-          chmod +x /opt/avro/avro-tools-1.11.3.jar
-          echo "alias avro-tools='java -jar /opt/avro/avro-tools-1.11.3.jar'" > ~/.bashrc
+          mv avro-tools-1.11.5.jar /opt/avro/
+          chmod +x /opt/avro/avro-tools-1.11.5.jar
+          echo "alias avro-tools='java -jar /opt/avro/avro-tools-1.11.5.jar'" > ~/.bashrc
       - name: End to end tests
         shell: bash
         if: matrix.java_version == '17'

--- a/dbeam-bom/pom.xml
+++ b/dbeam-bom/pom.xml
@@ -47,7 +47,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>attach-effective-pom</id>

--- a/dbeam-core/pom.xml
+++ b/dbeam-core/pom.xml
@@ -93,8 +93,8 @@
     <!-- Test Deps -->
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dbeam-core/src/test/java/com/spotify/dbeam/args/JdbcExportOptionsTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/args/JdbcExportOptionsTest.java
@@ -33,21 +33,21 @@ import java.util.Optional;
 import org.apache.avro.file.CodecFactory;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class JdbcExportOptionsTest {
   private static File sqlFile;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws IOException {
     sqlFile = File.createTempFile("query", ".sql");
     sqlFile.deleteOnExit();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() throws IOException {
     Files.delete(sqlFile.toPath());
   }
@@ -63,27 +63,33 @@ public class JdbcExportOptionsTest {
     return JdbcExportArgsFactory.fromPipelineOptions(opts);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailParseOnInvalidArg() throws IOException, ClassNotFoundException {
-    optionsFromArgs("--foo=bar");
+  @Test
+  public void shouldFailParseOnInvalidArg() {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> optionsFromArgs("--foo=bar"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnMissingConnectionUrl() throws IOException, ClassNotFoundException {
-    optionsFromArgs("--table=sometable");
+  @Test
+  public void shouldFailOnMissingConnectionUrl() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> optionsFromArgs("--table=sometable"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnMissingTableAndSqlFile() throws IOException, ClassNotFoundException {
-    optionsFromArgs("--connectionUrl=jdbc:postgresql://some_db");
+  @Test
+  public void shouldFailOnMissingTableAndSqlFile() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> optionsFromArgs("--connectionUrl=jdbc:postgresql://some_db"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnTableAndSqlFilePresent() throws IOException, ClassNotFoundException {
-    optionsFromArgs(
-        "--connectionUrl=jdbc:postgresql://some_db --sqlFile="
-            + sqlFile.getAbsolutePath()
-            + " --table=some_table");
+  @Test
+  public void shouldFailOnTableAndSqlFilePresent() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            optionsFromArgs(
+                "--connectionUrl=jdbc:postgresql://some_db --sqlFile="
+                    + sqlFile.getAbsolutePath()
+                    + " --table=some_table"));
   }
 
   @Test
@@ -100,7 +106,7 @@ public class JdbcExportOptionsTest {
             QueryBuilderArgs.createFromQuery(
                 com.google.common.io.Files.asCharSource(sqlFile, StandardCharsets.UTF_8).read()));
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -116,7 +122,7 @@ public class JdbcExportOptionsTest {
                     .withUsername("dbeam-extractor")),
             QueryBuilderArgs.create("some_table"));
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -130,56 +136,77 @@ public class JdbcExportOptionsTest {
                 JdbcConnectionArgs.create("jdbc:mysql://some_db").withUsername("dbeam-extractor")),
             QueryBuilderArgs.create("some_table"));
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnInvalidTable() throws IOException, ClassNotFoundException {
-    optionsFromArgs("--connectionUrl=jdbc:postgresql://some_db --table=some-table-with-dash");
+  @Test
+  public void shouldFailOnInvalidTable() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            optionsFromArgs(
+                "--connectionUrl=jdbc:postgresql://some_db --table=some-table-with-dash"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnNonJdbcUrl() throws IOException, ClassNotFoundException {
-    optionsFromArgs("--connectionUrl=bar --table=sometable");
+  @Test
+  public void shouldFailOnNonJdbcUrl() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> optionsFromArgs("--connectionUrl=bar --table=sometable"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnUnsupportedJdbcUrl() throws IOException, ClassNotFoundException {
-    optionsFromArgs("--connectionUrl=jdbc:paradox:./foo --table=sometable");
+  @Test
+  public void shouldFailOnUnsupportedJdbcUrl() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> optionsFromArgs("--connectionUrl=jdbc:paradox:./foo --table=sometable"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnMissingPartitionButPresentPartitionColumn()
-      throws IOException, ClassNotFoundException {
-    optionsFromArgs(
-        "--connectionUrl=jdbc:postgresql://some_db --table=sometable " + "--partitionColumn=col");
+  @Test
+  public void shouldFailOnMissingPartitionButPresentPartitionColumn() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            optionsFromArgs(
+                "--connectionUrl=jdbc:postgresql://some_db --table=sometable "
+                    + "--partitionColumn=col"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnTooOldPartition() throws IOException, ClassNotFoundException {
-    optionsFromArgs(
-        "--connectionUrl=jdbc:postgresql://some_db --table=sometable " + "--partition=2015-01-01");
+  @Test
+  public void shouldFailOnTooOldPartition() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            optionsFromArgs(
+                "--connectionUrl=jdbc:postgresql://some_db --table=sometable "
+                    + "--partition=2015-01-01"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnTooOldPartitionWithConfiguredMinPartitionPeriodMoreThanPartition()
-      throws IOException, ClassNotFoundException {
-    optionsFromArgs(
-        "--connectionUrl=jdbc:postgresql://some_db --table=sometable "
-            + "--partition=2015-01-01 --minPartitionPeriod=2015-01-02");
+  @Test
+  public void shouldFailOnTooOldPartitionWithConfiguredMinPartitionPeriodMoreThanPartition() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            optionsFromArgs(
+                "--connectionUrl=jdbc:postgresql://some_db --table=sometable "
+                    + "--partition=2015-01-01 --minPartitionPeriod=2015-01-02"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnTooOldPartitionWithConfiguredMinPartitionPeriodLessThanPartition()
-      throws IOException, ClassNotFoundException {
-    optionsFromArgs(
-        "--connectionUrl=jdbc:postgresql://some_db --table=sometable "
-            + "--partition=2015-01-01 --minPartitionPeriod=2015-01-01");
+  @Test
+  public void shouldFailOnTooOldPartitionWithConfiguredMinPartitionPeriodLessThanPartition() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            optionsFromArgs(
+                "--connectionUrl=jdbc:postgresql://some_db --table=sometable "
+                    + "--partition=2015-01-01 --minPartitionPeriod=2015-01-01"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnNonJdbcUrl2() throws IOException, ClassNotFoundException {
-    optionsFromArgs("--connectionUrl=some:foo:bar --table=sometable");
+  @Test
+  public void shouldFailOnNonJdbcUrl2() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> optionsFromArgs("--connectionUrl=some:foo:bar --table=sometable"));
   }
 
   @Test
@@ -197,7 +224,7 @@ public class JdbcExportOptionsTest {
                     .withPassword("somepassword")),
             QueryBuilderArgs.create("some_table"));
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -207,7 +234,7 @@ public class JdbcExportOptionsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--password=secret --useAvroLogicalTypes=true");
 
-    Assert.assertTrue(options.useAvroLogicalTypes());
+    Assertions.assertTrue(options.useAvroLogicalTypes());
   }
 
   @Test
@@ -217,7 +244,7 @@ public class JdbcExportOptionsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--password=secret --avroDoc=somedoc");
 
-    Assert.assertEquals(Optional.of("somedoc"), options.avroDoc());
+    Assertions.assertEquals(Optional.of("somedoc"), options.avroDoc());
   }
 
   @Test
@@ -227,7 +254,7 @@ public class JdbcExportOptionsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--password=secret --avroSchemaNamespace=ns");
 
-    Assert.assertEquals("ns", options.avroSchemaNamespace());
+    Assertions.assertEquals("ns", options.avroSchemaNamespace());
   }
 
   @Test
@@ -238,7 +265,7 @@ public class JdbcExportOptionsTest {
               "--connectionUrl=jdbc:postgresql://some_db", "--table=some_table", "--password=secret"
             });
 
-    Assert.assertEquals(false, defaultDataOnlyoptions.as(OutputOptions.class).getDataOnly());
+    Assertions.assertEquals(false, defaultDataOnlyoptions.as(OutputOptions.class).getDataOnly());
   }
 
   @Test
@@ -252,7 +279,7 @@ public class JdbcExportOptionsTest {
               "--dataOnly"
             });
 
-    Assert.assertEquals(true, options.as(OutputOptions.class).getDataOnly());
+    Assertions.assertEquals(true, options.as(OutputOptions.class).getDataOnly());
   }
 
   @Test
@@ -262,7 +289,7 @@ public class JdbcExportOptionsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--password=secret --fetchSize=1234");
 
-    Assert.assertEquals(1234, options.jdbcAvroOptions().fetchSize());
+    Assertions.assertEquals(1234, options.jdbcAvroOptions().fetchSize());
   }
 
   @Test
@@ -274,7 +301,7 @@ public class JdbcExportOptionsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--password=secret --partitionPeriod=P1M --partition=2050-12");
 
-    Assert.assertEquals(Period.ofMonths(1), options.queryBuilderArgs().partitionPeriod());
+    Assertions.assertEquals(Period.ofMonths(1), options.queryBuilderArgs().partitionPeriod());
   }
 
   @Test
@@ -284,8 +311,8 @@ public class JdbcExportOptionsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--password=secret --avroCodec=deflate7");
 
-    Assert.assertEquals("deflate7", options.jdbcAvroOptions().avroCodec());
-    Assert.assertEquals(
+    Assertions.assertEquals("deflate7", options.jdbcAvroOptions().avroCodec());
+    Assertions.assertEquals(
         CodecFactory.deflateCodec(7).toString(),
         options.jdbcAvroOptions().getCodecFactory().toString());
   }
@@ -297,8 +324,8 @@ public class JdbcExportOptionsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--password=secret --avroCodec=zstandard9");
 
-    Assert.assertEquals("zstandard9", options.jdbcAvroOptions().avroCodec());
-    Assert.assertEquals(
+    Assertions.assertEquals("zstandard9", options.jdbcAvroOptions().avroCodec());
+    Assertions.assertEquals(
         CodecFactory.zstandardCodec(9).toString(),
         options.jdbcAvroOptions().getCodecFactory().toString());
   }
@@ -310,8 +337,8 @@ public class JdbcExportOptionsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--password=secret --avroCodec=snappy");
 
-    Assert.assertEquals("snappy", options.jdbcAvroOptions().avroCodec());
-    Assert.assertEquals(
+    Assertions.assertEquals("snappy", options.jdbcAvroOptions().avroCodec());
+    Assertions.assertEquals(
         CodecFactory.snappyCodec().toString(),
         options.jdbcAvroOptions().getCodecFactory().toString());
   }
@@ -328,44 +355,58 @@ public class JdbcExportOptionsTest {
               "--preCommand=set bar=2"
             });
 
-    Assert.assertEquals("set foo='1'", options.jdbcAvroOptions().preCommand().get(0));
-    Assert.assertEquals("set bar=2", options.jdbcAvroOptions().preCommand().get(1));
+    Assertions.assertEquals("set foo='1'", options.jdbcAvroOptions().preCommand().get(0));
+    Assertions.assertEquals("set bar=2", options.jdbcAvroOptions().preCommand().get(1));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnInvalidAvroCodec() throws IOException, ClassNotFoundException {
-    optionsFromArgs(
-        "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
-            + "--password=secret --avroCodec=lzma");
+  @Test
+  public void shouldFailOnInvalidAvroCodec() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            optionsFromArgs(
+                "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
+                    + "--password=secret --avroCodec=lzma"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnQueryParallelismWithNoSplitColumn()
-      throws IOException, ClassNotFoundException {
-    optionsFromArgs(
-        "--connectionUrl=jdbc:postgresql://some_db "
-            + "--table=some_table --password=secret --queryParallelism=10");
+  @Test
+  public void shouldFailOnQueryParallelismWithNoSplitColumn() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            optionsFromArgs(
+                "--connectionUrl=jdbc:postgresql://some_db "
+                    + "--table=some_table --password=secret --queryParallelism=10"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnSplitColumnWithNoQueryParallelism()
-      throws IOException, ClassNotFoundException {
-    optionsFromArgs(
-        "--connectionUrl=jdbc:postgresql://some_db "
-            + "--table=some_table --password=secret --splitColumn=id");
+  @Test
+  public void shouldFailOnSplitColumnWithNoQueryParallelism() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            optionsFromArgs(
+                "--connectionUrl=jdbc:postgresql://some_db "
+                    + "--table=some_table --password=secret --splitColumn=id"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnZeroQueryParallelism() throws IOException, ClassNotFoundException {
-    optionsFromArgs(
-        "--connectionUrl=jdbc:postgresql://some_db "
-            + "--table=some_table --password=secret --queryParallelism=0 --splitColumn=id");
+  @Test
+  public void shouldFailOnZeroQueryParallelism() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            optionsFromArgs(
+                "--connectionUrl=jdbc:postgresql://some_db "
+                    + "--table=some_table --password=secret"
+                    + " --queryParallelism=0 --splitColumn=id"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnNegativeQueryParallelism() throws IOException, ClassNotFoundException {
-    optionsFromArgs(
-        "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
-            + "--password=secret --queryParallelism=-5 --splitColumn=id");
+  @Test
+  public void shouldFailOnNegativeQueryParallelism() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            optionsFromArgs(
+                "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
+                    + "--password=secret --queryParallelism=-5 --splitColumn=id"));
   }
 }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/args/ParallelQueryBuilderTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/args/ParallelQueryBuilderTest.java
@@ -26,8 +26,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import com.google.common.collect.Lists;
 import java.util.List;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ParallelQueryBuilderTest {
 
@@ -91,7 +91,7 @@ public class ParallelQueryBuilderTest {
         Matchers.is(Lists.newArrayList(format("%s AND sp >= %s AND sp <= %s", QUERY_BASE, 1, 10))));
   }
 
-  @Ignore // TODO: fix this
+  @Disabled("TODO: fix this")
   @Test
   public void shouldBuildMultipleQueriesWhenQueryingFromTwoRows() {
     final List<String> actual = ParallelQueryBuilder.queriesForBounds(1, 2, 2, "sp", QUERY_FORMAT);

--- a/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderArgsTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderArgsTest.java
@@ -34,10 +34,10 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Optional;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class QueryBuilderArgsTest {
 
@@ -46,7 +46,7 @@ public class QueryBuilderArgsTest {
   private static Connection connection;
   private static Path coffeesSqlQueryPath;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws SQLException, ClassNotFoundException, IOException {
     coffeesSqlQueryPath =
         TestHelper.createTmpDirPath("jdbc-export-args-test").resolve("coffees_query_1.sql");
@@ -57,19 +57,20 @@ public class QueryBuilderArgsTest {
     DbTestHelper.createFixtures(CONNECTION_URL);
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() throws SQLException {
     connection.close();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldFailOnNullTableName() {
-    QueryBuilderArgs.create(null);
+    Assertions.assertThrows(IllegalArgumentException.class, () -> QueryBuilderArgs.create(null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldFailOnInvalidTableName() {
-    QueryBuilderArgs.create("*invalid#name@!");
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> QueryBuilderArgs.create("*invalid#name@!"));
   }
 
   public void shouldNotFailOnTableNameWithDots() {
@@ -80,7 +81,7 @@ public class QueryBuilderArgsTest {
   public void shouldCreateValidSqlQueryFromUserQuery() throws SQLException {
     final QueryBuilderArgs args = QueryBuilderArgs.createFromQuery("SELECT * FROM some_table");
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Lists.newArrayList("SELECT * FROM (SELECT * FROM some_table) as user_sql_query WHERE 1=1"),
         args.buildQueries(null));
   }
@@ -90,7 +91,7 @@ public class QueryBuilderArgsTest {
     final QueryBuilderArgs actual =
         parseOptions("--connectionUrl=jdbc:postgresql://some_db --table=some_table " + "--limit=7");
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Lists.newArrayList("SELECT * FROM some_table WHERE 1=1 LIMIT 7"),
         actual.buildQueries(null));
   }
@@ -102,8 +103,8 @@ public class QueryBuilderArgsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-07-31");
 
-    Assert.assertEquals(Optional.of(Instant.parse("2027-07-31T00:00:00Z")), actual.partition());
-    Assert.assertEquals(
+    Assertions.assertEquals(Optional.of(Instant.parse("2027-07-31T00:00:00Z")), actual.partition());
+    Assertions.assertEquals(
         Lists.newArrayList("SELECT * FROM some_table WHERE 1=1"), actual.buildQueries(null));
   }
 
@@ -114,7 +115,7 @@ public class QueryBuilderArgsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-07-31T13:37:59Z");
 
-    Assert.assertEquals(Optional.of(Instant.parse("2027-07-31T13:37:59Z")), actual.partition());
+    Assertions.assertEquals(Optional.of(Instant.parse("2027-07-31T13:37:59Z")), actual.partition());
   }
 
   @Test
@@ -124,7 +125,7 @@ public class QueryBuilderArgsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-05");
 
-    Assert.assertEquals(Optional.of(Instant.parse("2027-05-01T00:00:00Z")), actual.partition());
+    Assertions.assertEquals(Optional.of(Instant.parse("2027-05-01T00:00:00Z")), actual.partition());
   }
 
   @Test
@@ -134,7 +135,7 @@ public class QueryBuilderArgsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-05-02T23");
 
-    Assert.assertEquals(Optional.of(Instant.parse("2027-05-02T23:00:00Z")), actual.partition());
+    Assertions.assertEquals(Optional.of(Instant.parse("2027-05-02T23:00:00Z")), actual.partition());
   }
 
   @Test
@@ -144,7 +145,7 @@ public class QueryBuilderArgsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-07-31 --partitionColumn=col");
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Lists.newArrayList(
             "SELECT * FROM some_table WHERE 1=1 "
                 + "AND col >= '2027-07-31' AND col < '2027-08-01'"),
@@ -158,7 +159,7 @@ public class QueryBuilderArgsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-07-31 --partitionColumn=col --limit=5");
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Lists.newArrayList(
             "SELECT * FROM some_table WHERE 1=1 "
                 + "AND col >= '2027-07-31' AND col < '2027-08-01' LIMIT 5"),
@@ -172,7 +173,7 @@ public class QueryBuilderArgsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-07-31 --partitionColumn=col --partitionPeriod=P1M");
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Lists.newArrayList(
             "SELECT * FROM some_table WHERE 1=1 "
                 + "AND col >= '2027-07-31' AND col < '2027-08-31'"),
@@ -187,7 +188,7 @@ public class QueryBuilderArgsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-07-31T00 --partitionColumn=col --partitionPeriod=PT1H");
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Lists.newArrayList(
             "SELECT * FROM some_table WHERE 1=1 "
                 + "AND col >= '2027-07-31T00:00:00Z' AND col < '2027-07-31T01:00:00Z'"),
@@ -204,7 +205,7 @@ public class QueryBuilderArgsTest {
                 "--connectionUrl=jdbc:postgresql://some_db " + "--sqlFile=%s --limit=7",
                 coffeesSqlQueryPath.toString()));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Lists.newArrayList(
             "SELECT * FROM (SELECT * FROM COFFEES WHERE SIZE > 10) as user_sql_query"
                 + " WHERE 1=1 LIMIT 7"),
@@ -220,7 +221,7 @@ public class QueryBuilderArgsTest {
                     + "--sqlFile=%s --partition=2027-07-31 --partitionColumn=col --limit=7",
                 coffeesSqlQueryPath.toString()));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Lists.newArrayList(
             "SELECT * FROM (SELECT * FROM COFFEES WHERE SIZE > 10) as user_sql_query WHERE 1=1 "
                 + "AND col >= '2027-07-31' AND col < '2027-08-01' LIMIT 7"),
@@ -238,7 +239,7 @@ public class QueryBuilderArgsTest {
                     + "--partitionColumn=col --partitionPeriod=P1M",
                 coffeesSqlQueryPath.toString()));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Lists.newArrayList(
             "SELECT * FROM (SELECT * FROM COFFEES WHERE SIZE > 10) as user_sql_query WHERE 1=1 "
                 + "AND col >= '2027-07-31' AND col < '2027-08-31'"),
@@ -253,7 +254,7 @@ public class QueryBuilderArgsTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=COFFEES "
                 + "--splitColumn=ROWNUM --queryParallelism=5");
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Lists.newArrayList("SELECT * FROM COFFEES WHERE 1=1" + " AND ROWNUM >= 1 AND ROWNUM <= 2"),
         actual.buildQueries(connection));
   }
@@ -267,7 +268,7 @@ public class QueryBuilderArgsTest {
                     + "--sqlFile=%s --splitColumn=ROWNUM --queryParallelism=5",
                 coffeesSqlQueryPath.toString()));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Lists.newArrayList(
             "SELECT * FROM (SELECT * FROM COFFEES WHERE SIZE > 10) as user_sql_query WHERE 1=1"
                 + " AND ROWNUM >= 1 AND ROWNUM <= 2"),
@@ -284,7 +285,7 @@ public class QueryBuilderArgsTest {
                     + "--partitionColumn=col --partitionPeriod=P1M --limit=7",
                 coffeesSqlQueryPath.toString()));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Lists.newArrayList(
             "SELECT * FROM (SELECT * FROM COFFEES WHERE SIZE > 10) as user_sql_query WHERE 1=1"
                 + " AND col >= '2027-07-31' AND col < '2027-08-31' LIMIT 7"),

--- a/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/args/QueryBuilderTest.java
@@ -22,8 +22,8 @@ package com.spotify.dbeam.args;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class QueryBuilderTest {
 
@@ -33,7 +33,7 @@ public class QueryBuilderTest {
 
     final String expected = "SELECT * FROM abc WHERE 1=1";
 
-    Assert.assertEquals(expected, wrapper.build());
+    Assertions.assertEquals(expected, wrapper.build());
   }
 
   @Test
@@ -42,7 +42,7 @@ public class QueryBuilderTest {
 
     final String expected = "SELECT * FROM (SELECT * FROM t1) as user_sql_query WHERE 1=1";
 
-    Assert.assertEquals(expected, wrapper.build());
+    Assertions.assertEquals(expected, wrapper.build());
   }
 
   @Test
@@ -50,7 +50,7 @@ public class QueryBuilderTest {
     final QueryBuilder q1 = QueryBuilder.fromSqlQuery("SELECT * FROM t1");
     final QueryBuilder copy = q1.withPartitionCondition("pary", "20180101", "20180201");
 
-    Assert.assertNotEquals(q1.build(), copy.build());
+    Assertions.assertNotEquals(q1.build(), copy.build());
   }
 
   @Test
@@ -58,7 +58,7 @@ public class QueryBuilderTest {
     final QueryBuilder q1 = QueryBuilder.fromSqlQuery("SELECT * FROM t1");
     final QueryBuilder copy = q1.withLimit(3L);
 
-    Assert.assertNotEquals(q1.build(), copy.build());
+    Assertions.assertNotEquals(q1.build(), copy.build());
   }
 
   @Test
@@ -68,7 +68,7 @@ public class QueryBuilderTest {
     final String expected =
         "SELECT * FROM (SELECT * FROM t1 WHERE a > 100) as user_sql_query WHERE 1=1";
 
-    Assert.assertEquals(expected, wrapper.build());
+    Assertions.assertEquals(expected, wrapper.build());
   }
 
   @Test
@@ -78,7 +78,7 @@ public class QueryBuilderTest {
     final String expected =
         "SELECT * FROM (SELECT * FROM t1) as user_sql_query WHERE 1=1 LIMIT 102";
 
-    Assert.assertEquals(expected, wrapper.build());
+    Assertions.assertEquals(expected, wrapper.build());
   }
 
   @Test
@@ -91,7 +91,7 @@ public class QueryBuilderTest {
         "SELECT * FROM (SELECT * FROM t1) as user_sql_query"
             + " WHERE 1=1 AND bucket >= 10 AND bucket < 20";
 
-    Assert.assertEquals(expected, wrapper.build());
+    Assertions.assertEquals(expected, wrapper.build());
   }
 
   @Test
@@ -104,7 +104,7 @@ public class QueryBuilderTest {
         "SELECT * FROM (SELECT * FROM t1) as user_sql_query WHERE 1=1"
             + " AND birthDate >= '2018-01-01' AND birthDate < '2018-02-01'";
 
-    Assert.assertEquals(expected, wrapper.build());
+    Assertions.assertEquals(expected, wrapper.build());
   }
 
   @Test
@@ -117,7 +117,7 @@ public class QueryBuilderTest {
         "SELECT * FROM (SELECT a, b, c FROM t1\n WHERE total > 100\n AND country = 262\n)"
             + " as user_sql_query WHERE 1=1";
 
-    Assert.assertEquals(expected, wrapper.build());
+    Assertions.assertEquals(expected, wrapper.build());
   }
 
   @Test
@@ -131,7 +131,7 @@ public class QueryBuilderTest {
             + "-- We perform initial query here\nSELECT a, b, c FROM t1\n WHERE total > 100)"
             + " as user_sql_query WHERE 1=1";
 
-    Assert.assertEquals(expected, wrapper.build());
+    Assertions.assertEquals(expected, wrapper.build());
   }
 
   @Test
@@ -161,7 +161,7 @@ public class QueryBuilderTest {
             + "GROUP BY date\n"
             + ") as user_sql_query WHERE 1=1";
 
-    Assert.assertEquals(expected, wrapper.build());
+    Assertions.assertEquals(expected, wrapper.build());
   }
 
   @Test
@@ -207,12 +207,12 @@ public class QueryBuilderTest {
             .withPartitionCondition("partition", "a", "d")
             .generateQueryToGetLimitsOfSplitColumn("splitCol", "mixy", "maxy")
             .build();
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   private void execAndCompare(String rawInput, String expected) {
     final String actual = QueryBuilder.fromSqlQuery(rawInput).build();
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
@@ -244,7 +244,7 @@ public class JdbcAvroRecordTest {
             Optional.ofNullable((Long) record.get(9)).map(Timestamp::new),
             TestHelper.byteBufferToUuid((ByteBuffer) record.get(10)),
             (Long) record.get(11),
-            new ArrayList<>((GenericData.Array<Integer>) record.get(12)),
+            new ArrayList<>((List<Integer>) record.get(12)),
             actualTxtArray);
     Assertions.assertEquals(Coffee.COFFEE1, actual);
   }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
@@ -57,9 +57,9 @@ import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.util.Utf8;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.postgresql.jdbc.PgArray;
 
@@ -68,7 +68,7 @@ public class JdbcAvroRecordTest {
   private static String CONNECTION_URL =
       "jdbc:h2:mem:test;MODE=PostgreSQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1";
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws SQLException, ClassNotFoundException {
     DbTestHelper.createFixtures(CONNECTION_URL);
   }
@@ -85,14 +85,14 @@ public class JdbcAvroRecordTest {
             "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test",
             false, ArrayHandlingMode.TypedMetaFromFirstRow, false);
 
-    Assert.assertNotNull(actual);
-    Assert.assertEquals("dbeam_generated", actual.getNamespace());
-    Assert.assertEquals("COFFEES", actual.getProp("tableName"));
-    Assert.assertEquals("jdbc:h2:mem:test", actual.getProp("connectionUrl"));
-    Assert.assertEquals(
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals("dbeam_generated", actual.getNamespace());
+    Assertions.assertEquals("COFFEES", actual.getProp("tableName"));
+    Assertions.assertEquals("jdbc:h2:mem:test", actual.getProp("connectionUrl"));
+    Assertions.assertEquals(
         "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test", actual.getDoc());
-    Assert.assertEquals(fieldCount, actual.getFields().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(fieldCount, actual.getFields().size());
+    Assertions.assertEquals(
         Lists.newArrayList(
             "COF_NAME",
             "SUP_ID",
@@ -110,45 +110,46 @@ public class JdbcAvroRecordTest {
             "TEXT_ARR"),
         actual.getFields().stream().map(Schema.Field::name).collect(Collectors.toList()));
     for (Schema.Field f : actual.getFields()) {
-      Assert.assertEquals(Schema.Type.UNION, f.schema().getType());
-      Assert.assertEquals(2, f.schema().getTypes().size());
-      Assert.assertEquals(Schema.Type.NULL, f.schema().getTypes().get(0).getType());
+      Assertions.assertEquals(Schema.Type.UNION, f.schema().getType());
+      Assertions.assertEquals(2, f.schema().getTypes().size());
+      Assertions.assertEquals(Schema.Type.NULL, f.schema().getTypes().get(0).getType());
     }
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.STRING, actual.getField("COF_NAME").schema().getTypes().get(1).getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.INT, actual.getField("SUP_ID").schema().getTypes().get(1).getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.STRING, actual.getField("PRICE").schema().getTypes().get(1).getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.FLOAT, actual.getField("TEMPERATURE").schema().getTypes().get(1).getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.DOUBLE, actual.getField("SIZE").schema().getTypes().get(1).getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.BOOLEAN, actual.getField("IS_ARABIC").schema().getTypes().get(1).getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.INT, actual.getField("SALES").schema().getTypes().get(1).getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.LONG, actual.getField("TOTAL").schema().getTypes().get(1).getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.LONG, actual.getField("CREATED").schema().getTypes().get(1).getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.LONG, actual.getField("UPDATED").schema().getTypes().get(1).getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.BYTES, actual.getField("UID").schema().getTypes().get(1).getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.LONG, actual.getField("ROWNUM").schema().getTypes().get(1).getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.ARRAY, actual.getField("INT_ARR").schema().getTypes().get(1).getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.INT,
         actual.getField("INT_ARR").schema().getTypes().get(1).getElementType().getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.ARRAY, actual.getField("TEXT_ARR").schema().getTypes().get(1).getType());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Schema.Type.STRING,
         actual.getField("TEXT_ARR").schema().getTypes().get(1).getElementType().getType());
-    Assert.assertNull(actual.getField("UPDATED").schema().getTypes().get(1).getProp("logicalType"));
+    Assertions.assertNull(
+        actual.getField("UPDATED").schema().getTypes().get(1).getProp("logicalType"));
   }
 
   @Test
@@ -163,8 +164,8 @@ public class JdbcAvroRecordTest {
             "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test",
             true, ArrayHandlingMode.TypedMetaFromFirstRow, false);
 
-    Assert.assertEquals(fieldCount, actual.getFields().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(fieldCount, actual.getFields().size());
+    Assertions.assertEquals(
         "timestamp-millis",
         actual.getField("UPDATED").schema().getTypes().get(1).getProp("logicalType"));
   }
@@ -180,7 +181,7 @@ public class JdbcAvroRecordTest {
             "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test",
             false, ArrayHandlingMode.TypedMetaFromFirstRow, false);
 
-    Assert.assertEquals("CustomSchemaName", actual.getName());
+    Assertions.assertEquals("CustomSchemaName", actual.getName());
   }
 
   @Test
@@ -217,15 +218,15 @@ public class JdbcAvroRecordTest {
     final List<GenericRecord> records =
         StreamSupport.stream(dataFileReader.spliterator(), false).collect(Collectors.toList());
 
-    Assert.assertEquals(2, records.size());
+    Assertions.assertEquals(2, records.size());
     final GenericRecord record =
         records.stream()
             .filter(r -> Coffee.COFFEE1.name().equals(r.get(0).toString()))
             .findFirst()
             .orElseThrow(() -> new IllegalArgumentException("not found"));
 
-    Assert.assertEquals(14, record.getSchema().getFields().size());
-    Assert.assertEquals(schema, record.getSchema());
+    Assertions.assertEquals(14, record.getSchema().getFields().size());
+    Assertions.assertEquals(schema, record.getSchema());
     List<String> actualTxtArray =
         ((GenericData.Array<Utf8>) record.get(13))
             .stream().map(x -> x.toString()).collect(Collectors.toList());
@@ -245,7 +246,7 @@ public class JdbcAvroRecordTest {
             (Long) record.get(11),
             new ArrayList<>((GenericData.Array<Integer>) record.get(12)),
             actualTxtArray);
-    Assert.assertEquals(Coffee.COFFEE1, actual);
+    Assertions.assertEquals(Coffee.COFFEE1, actual);
   }
 
   @Test
@@ -267,7 +268,7 @@ public class JdbcAvroRecordTest {
     when(resultSet.getLong(columnNum)).thenReturn(valueUnderTest);
     final Object result = mapping.apply(resultSet);
 
-    Assert.assertEquals(Long.class, result.getClass());
-    Assert.assertEquals(valueUnderTest, ((Long) result).longValue());
+    Assertions.assertEquals(Long.class, result.getClass());
+    Assertions.assertEquals(valueUnderTest, ((Long) result).longValue());
   }
 }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
@@ -29,8 +29,8 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Optional;
 import org.apache.avro.Schema;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class JdbcAvroSchemaTest {
@@ -43,7 +43,7 @@ public class JdbcAvroSchemaTest {
     when(meta.getColumnCount()).thenReturn(1);
     when(meta.getTableName(1)).thenReturn("test_table");
 
-    Assert.assertEquals("test_table", JdbcAvroSchema.getDatabaseTableName(meta));
+    Assertions.assertEquals("test_table", JdbcAvroSchema.getDatabaseTableName(meta));
   }
 
   @Test
@@ -52,7 +52,7 @@ public class JdbcAvroSchemaTest {
     when(meta.getColumnCount()).thenReturn(1);
     when(meta.getTableName(1)).thenReturn("");
 
-    Assert.assertEquals("no_table_name", JdbcAvroSchema.getDatabaseTableName(meta));
+    Assertions.assertEquals("no_table_name", JdbcAvroSchema.getDatabaseTableName(meta));
   }
 
   @Test
@@ -61,7 +61,7 @@ public class JdbcAvroSchemaTest {
     when(meta.getColumnCount()).thenReturn(1);
     when(meta.getTableName(1)).thenReturn(null);
 
-    Assert.assertEquals("no_table_name", JdbcAvroSchema.getDatabaseTableName(meta));
+    Assertions.assertEquals("no_table_name", JdbcAvroSchema.getDatabaseTableName(meta));
   }
 
   @Test
@@ -71,7 +71,7 @@ public class JdbcAvroSchemaTest {
     when(meta.getTableName(1)).thenReturn("");
     when(meta.getTableName(2)).thenReturn("test_table");
 
-    Assert.assertEquals("test_table", JdbcAvroSchema.getDatabaseTableName(meta));
+    Assertions.assertEquals("test_table", JdbcAvroSchema.getDatabaseTableName(meta));
   }
 
   @Test
@@ -80,8 +80,8 @@ public class JdbcAvroSchemaTest {
 
     final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, true);
 
-    Assert.assertEquals(Schema.Type.LONG, fieldSchema.getType());
-    Assert.assertEquals("timestamp-millis", fieldSchema.getProp("logicalType"));
+    Assertions.assertEquals(Schema.Type.LONG, fieldSchema.getType());
+    Assertions.assertEquals("timestamp-millis", fieldSchema.getProp("logicalType"));
   }
 
   @Test
@@ -90,8 +90,8 @@ public class JdbcAvroSchemaTest {
 
     final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
 
-    Assert.assertEquals(Schema.Type.LONG, fieldSchema.getType());
-    Assert.assertNull(fieldSchema.getProp("logicalType"));
+    Assertions.assertEquals(Schema.Type.LONG, fieldSchema.getType());
+    Assertions.assertNull(fieldSchema.getProp("logicalType"));
   }
 
   @Test
@@ -100,7 +100,7 @@ public class JdbcAvroSchemaTest {
 
     final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
 
-    Assert.assertEquals(Schema.Type.LONG, fieldSchema.getType());
+    Assertions.assertEquals(Schema.Type.LONG, fieldSchema.getType());
   }
 
   @Test
@@ -109,7 +109,7 @@ public class JdbcAvroSchemaTest {
 
     final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
 
-    Assert.assertEquals(Schema.Type.BOOLEAN, fieldSchema.getType());
+    Assertions.assertEquals(Schema.Type.BOOLEAN, fieldSchema.getType());
   }
 
   @Test
@@ -119,30 +119,34 @@ public class JdbcAvroSchemaTest {
 
     final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
 
-    Assert.assertEquals(Schema.Type.BYTES, fieldSchema.getType());
+    Assertions.assertEquals(Schema.Type.BYTES, fieldSchema.getType());
   }
 
   @Test
   public void shouldThrowOnNonSupportedTypes() throws SQLException {
     final ResultSet resultSet = buildMockResultSet(Types.STRUCT);
-    RuntimeException thrown = Assert.assertThrows(RuntimeException.class,
-        () -> createAvroSchemaForSingleField(resultSet, false));
-    Assert.assertEquals("STRUCT type is not supported", thrown.getMessage());
+    RuntimeException thrown =
+        Assertions.assertThrows(
+            RuntimeException.class, () -> createAvroSchemaForSingleField(resultSet, false));
+    Assertions.assertEquals("STRUCT type is not supported", thrown.getMessage());
 
     final ResultSet resultSet2 = buildMockResultSet(Types.REF);
-    RuntimeException thrown2 = Assert.assertThrows(RuntimeException.class,
-        () -> createAvroSchemaForSingleField(resultSet2, false));
-    Assert.assertEquals("REF and REF_CURSOR type are not supported", thrown2.getMessage());
+    RuntimeException thrown2 =
+        Assertions.assertThrows(
+            RuntimeException.class, () -> createAvroSchemaForSingleField(resultSet2, false));
+    Assertions.assertEquals("REF and REF_CURSOR type are not supported", thrown2.getMessage());
 
     final ResultSet resultSet3 = buildMockResultSet(Types.REF_CURSOR);
-    RuntimeException thrown3 = Assert.assertThrows(RuntimeException.class,
-        () -> createAvroSchemaForSingleField(resultSet3, false));
-    Assert.assertEquals("REF and REF_CURSOR type are not supported", thrown3.getMessage());
+    RuntimeException thrown3 =
+        Assertions.assertThrows(
+            RuntimeException.class, () -> createAvroSchemaForSingleField(resultSet3, false));
+    Assertions.assertEquals("REF and REF_CURSOR type are not supported", thrown3.getMessage());
 
     final ResultSet resultSet4 = buildMockResultSet(Types.DATALINK);
-    RuntimeException thrown4 = Assert.assertThrows(RuntimeException.class,
-        () -> createAvroSchemaForSingleField(resultSet4, false));
-    Assert.assertEquals("DATALINK type is not supported", thrown4.getMessage());
+    RuntimeException thrown4 =
+        Assertions.assertThrows(
+            RuntimeException.class, () -> createAvroSchemaForSingleField(resultSet4, false));
+    Assertions.assertEquals("DATALINK type is not supported", thrown4.getMessage());
   }
 
   @Test
@@ -152,7 +156,7 @@ public class JdbcAvroSchemaTest {
 
     final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
 
-    Assert.assertEquals(Schema.Type.LONG, fieldSchema.getType());
+    Assertions.assertEquals(Schema.Type.LONG, fieldSchema.getType());
   }
 
   @Test
@@ -161,7 +165,7 @@ public class JdbcAvroSchemaTest {
 
     final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
 
-    Assert.assertEquals(Schema.Type.INT, fieldSchema.getType());
+    Assertions.assertEquals(Schema.Type.INT, fieldSchema.getType());
   }
 
   @Test
@@ -170,7 +174,7 @@ public class JdbcAvroSchemaTest {
 
     final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
 
-    Assert.assertEquals(Schema.Type.STRING, fieldSchema.getType());
+    Assertions.assertEquals(Schema.Type.STRING, fieldSchema.getType());
   }
 
   @Test
@@ -178,8 +182,8 @@ public class JdbcAvroSchemaTest {
     final ResultSet resultSet = buildMockResultSet(Types.OTHER, "uuid");
     final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, true);
 
-    Assert.assertEquals(Schema.Type.STRING, fieldSchema.getType());
-    Assert.assertEquals("uuid", fieldSchema.getProp("logicalType"));
+    Assertions.assertEquals(Schema.Type.STRING, fieldSchema.getType());
+    Assertions.assertEquals("uuid", fieldSchema.getProp("logicalType"));
   }
 
   @Test
@@ -187,8 +191,8 @@ public class JdbcAvroSchemaTest {
     final ResultSet resultSet = buildMockResultSet(Types.OTHER, "uuid");
     final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
 
-    Assert.assertEquals(Schema.Type.STRING, fieldSchema.getType());
-    Assert.assertNull(fieldSchema.getProp("logicalType"));
+    Assertions.assertEquals(Schema.Type.STRING, fieldSchema.getType());
+    Assertions.assertNull(fieldSchema.getProp("logicalType"));
   }
 
   private Schema createAvroSchemaForSingleField(

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/PostgresJdbcAvroTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/PostgresJdbcAvroTest.java
@@ -86,8 +86,7 @@ public class PostgresJdbcAvroTest {
   public void assertGenericRecordArrayField(GenericRecord record, String fieldName,
                                        Object... expectedItems) {
 
-    final GenericData.Array<GenericRecord> arrayValue =
-        (GenericData.Array<GenericRecord>) record.get(fieldName);
+    final List<?> arrayValue = (List<?>) record.get(fieldName);
     Assertions.assertEquals(expectedItems.length, arrayValue.size());
 
     for (int i = 0; i < expectedItems.length; i++) {

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/PostgresJdbcAvroTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/PostgresJdbcAvroTest.java
@@ -45,8 +45,8 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class PostgresJdbcAvroTest {
@@ -88,10 +88,10 @@ public class PostgresJdbcAvroTest {
 
     final GenericData.Array<GenericRecord> arrayValue =
         (GenericData.Array<GenericRecord>) record.get(fieldName);
-    Assert.assertEquals(expectedItems.length, arrayValue.size());
+    Assertions.assertEquals(expectedItems.length, arrayValue.size());
 
     for (int i = 0; i < expectedItems.length; i++) {
-      Assert.assertEquals(expectedItems[i], arrayValue.get(i));
+      Assertions.assertEquals(expectedItems[i], arrayValue.get(i));
     }
   }
 
@@ -118,7 +118,7 @@ public class PostgresJdbcAvroTest {
     GenericRecord actualRecord = bytesToGenericRecords(schema,
         converter.convertResultSetIntoAvroBytes())[0];
 
-    Assert.assertEquals(actualRecord.get("uuid_field"), new Utf8(uuidExpected.toString()));
+    Assertions.assertEquals(actualRecord.get("uuid_field"), new Utf8(uuidExpected.toString()));
     assertGenericRecordArrayField(actualRecord, "array_field", new Utf8(uuidExpected.toString()));
   }
 
@@ -149,10 +149,10 @@ public class PostgresJdbcAvroTest {
     final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(resultSet, arrayMode,
         false);
 
-    GenericRecord actualRecord = bytesToGenericRecords(schema,
-        converter.convertResultSetIntoAvroBytes())[0];
-    Assert.assertEquals(actualRecord.get("text_field"), new Utf8("some_text_42"));
-    Assert.assertEquals(actualRecord.get("other_field"), new Utf8("some_other_42"));
+    GenericRecord actualRecord =
+        bytesToGenericRecords(schema, converter.convertResultSetIntoAvroBytes())[0];
+    Assertions.assertEquals(actualRecord.get("text_field"), new Utf8("some_text_42"));
+    Assertions.assertEquals(actualRecord.get("other_field"), new Utf8("some_other_42"));
     assertGenericRecordArrayField(actualRecord, "array_field1", "some_text_42");
     assertGenericRecordArrayField(actualRecord, "array_field2", "some_varchar_42");
     assertGenericRecordArrayField(actualRecord, "array_other", "some_other_42");
@@ -168,9 +168,18 @@ public class PostgresJdbcAvroTest {
     when(resultSet.getArray(1)).thenReturn(null);
     when(resultSet.isFirst()).thenReturn(true);
 
-    Assert.assertThrows(RuntimeException.class, () -> JdbcAvroSchema.createAvroSchema(resultSet,
-        "ns", "conn_url",
-        Optional.empty(), "doc", true, ArrayHandlingMode.TypedMetaFromFirstRow, false));
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () ->
+            JdbcAvroSchema.createAvroSchema(
+                resultSet,
+                "ns",
+                "conn_url",
+                Optional.empty(),
+                "doc",
+                true,
+                ArrayHandlingMode.TypedMetaFromFirstRow,
+                false));
   }
 
   @Test
@@ -191,10 +200,10 @@ public class PostgresJdbcAvroTest {
     final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(resultSet, arrayMode,
         false);
 
-    GenericRecord actualRecord = bytesToGenericRecords(schema,
-        converter.convertResultSetIntoAvroBytes())[0];
-    Assert.assertArrayEquals(expectedValue,
-        ((java.nio.ByteBuffer) actualRecord.get("array_field")).array());
+    GenericRecord actualRecord =
+        bytesToGenericRecords(schema, converter.convertResultSetIntoAvroBytes())[0];
+    Assertions.assertArrayEquals(
+        expectedValue, ((java.nio.ByteBuffer) actualRecord.get("array_field")).array());
   }
 
   @Test
@@ -229,12 +238,12 @@ public class PostgresJdbcAvroTest {
     GenericRecord[] actualRecords = bytesToGenericRecords(schema,
         converter.convertResultSetIntoAvroBytes(), converter.convertResultSetIntoAvroBytes());
 
-    Assert.assertNull(actualRecords[0].get("array_field_varchar"));
-    Assert.assertNull(actualRecords[0].get("array_field_text"));
-    Assert.assertNull(actualRecords[0].get("array_field_uuid"));
-    Assert.assertNull(actualRecords[0].get("array_field_int"));
-    Assert.assertNull(actualRecords[0].get("array_field_int4"));
-    Assert.assertNull(actualRecords[0].get("array_field_int8"));
+    Assertions.assertNull(actualRecords[0].get("array_field_varchar"));
+    Assertions.assertNull(actualRecords[0].get("array_field_text"));
+    Assertions.assertNull(actualRecords[0].get("array_field_uuid"));
+    Assertions.assertNull(actualRecords[0].get("array_field_int"));
+    Assertions.assertNull(actualRecords[0].get("array_field_int4"));
+    Assertions.assertNull(actualRecords[0].get("array_field_int8"));
     assertGenericRecordArrayField(actualRecords[1], "array_field_varchar", "some_varchar_42", "42");
     assertGenericRecordArrayField(actualRecords[1], "array_field_text", "some_text_42", "42");
     assertGenericRecordArrayField(actualRecords[1], "array_field_uuid",
@@ -296,12 +305,14 @@ public class PostgresJdbcAvroTest {
     String arrayMode = ArrayHandlingMode.TypedMetaPostgres;
     boolean nullableArrayItems = false;
 
-    final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(resultSet, arrayMode,
-        nullableArrayItems);
-    RuntimeException thrown = Assert.assertThrows(RuntimeException.class,
-        () -> converter.convertResultSetIntoAvroBytes());
-    Assert.assertEquals("Array item is null in column 'array_field_varchar', use "
-                        + "--nullableArrayItems", thrown.getMessage());
+    final JdbcAvroRecordConverter converter =
+        JdbcAvroRecordConverter.create(resultSet, arrayMode, nullableArrayItems);
+    RuntimeException thrown =
+        Assertions.assertThrows(
+            RuntimeException.class, () -> converter.convertResultSetIntoAvroBytes());
+    Assertions.assertEquals(
+        "Array item is null in column 'array_field_varchar', use " + "--nullableArrayItems",
+        thrown.getMessage());
   }
 
   @Test
@@ -318,12 +329,14 @@ public class PostgresJdbcAvroTest {
     String arrayMode = ArrayHandlingMode.TypedMetaPostgres;
     boolean nullableArrayItems = false;
 
-    final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(resultSet, arrayMode,
-        nullableArrayItems);
-    RuntimeException thrown = Assert.assertThrows(RuntimeException.class,
-        () -> converter.convertResultSetIntoAvroBytes());
-    Assert.assertEquals("Value of type class java.io.File in column 'invalid_array' is not "
-                        + "supported", thrown.getMessage());
+    final JdbcAvroRecordConverter converter =
+        JdbcAvroRecordConverter.create(resultSet, arrayMode, nullableArrayItems);
+    RuntimeException thrown =
+        Assertions.assertThrows(
+            RuntimeException.class, () -> converter.convertResultSetIntoAvroBytes());
+    Assertions.assertEquals(
+        "Value of type class java.io.File in column 'invalid_array' is not " + "supported",
+        thrown.getMessage());
   }
 
   @Test
@@ -340,10 +353,21 @@ public class PostgresJdbcAvroTest {
     String arrayMode = ArrayHandlingMode.TypedMetaPostgres;
     boolean nullableArrayItems = true;
 
-    RuntimeException thrown = Assert.assertThrows(RuntimeException.class,
-        () -> JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
-            Optional.empty(), "doc", true, arrayMode, nullableArrayItems));
-    Assert.assertEquals("columnName=array_field_text columnTypeName=text should start with '_'",
+    RuntimeException thrown =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () ->
+                JdbcAvroSchema.createAvroSchema(
+                    resultSet,
+                    "ns",
+                    "conn_url",
+                    Optional.empty(),
+                    "doc",
+                    true,
+                    arrayMode,
+                    nullableArrayItems));
+    Assertions.assertEquals(
+        "columnName=array_field_text columnTypeName=text should start with '_'",
         thrown.getMessage());
   }
 
@@ -361,10 +385,20 @@ public class PostgresJdbcAvroTest {
     String arrayMode = ArrayHandlingMode.TypedMetaPostgres;
     boolean nullableArrayItems = true;
 
-    RuntimeException thrown = Assert.assertThrows(RuntimeException.class,
-        () -> JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
-            Optional.empty(), "doc", true, arrayMode, nullableArrayItems));
-    Assert.assertEquals(
+    RuntimeException thrown =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () ->
+                JdbcAvroSchema.createAvroSchema(
+                    resultSet,
+                    "ns",
+                    "conn_url",
+                    Optional.empty(),
+                    "doc",
+                    true,
+                    arrayMode,
+                    nullableArrayItems));
+    Assertions.assertEquals(
         "columnName=array_field_text Postgres type 'not_supported' is not supported",
         thrown.getMessage());
   }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/beam/BeamHelperTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/beam/BeamHelperTest.java
@@ -20,13 +20,13 @@
 
 package com.spotify.dbeam.beam;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BeamHelperTest {
 
@@ -40,9 +40,10 @@ public class BeamHelperTest {
     } catch (IOException e) {
       // Beam changed behavior - now throws IOException instead of FileNotFoundException
       // Verify it's the expected GCS error message
-      assertTrue("Exception should indicate GCS file matching error",
-          e.getMessage().contains("Error matching file spec") 
-          && e.getMessage().contains("gs://does-not-exist-1"));
+      assertTrue(
+          e.getMessage().contains("Error matching file spec")
+              && e.getMessage().contains("gs://does-not-exist-1"),
+          "Exception should indicate GCS file matching error");
     }
   }
 }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/jobs/BeamHelperTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/jobs/BeamHelperTest.java
@@ -26,8 +26,8 @@ import java.time.Duration;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.metrics.MetricResults;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BeamHelperTest {
 
@@ -62,9 +62,9 @@ public class BeamHelperTest {
         };
     try {
       BeamHelper.waitUntilDone(mockResult, Duration.ofMinutes(1));
-      Assert.fail("A PipelineExecutionException should be thrown");
+      Assertions.fail("A PipelineExecutionException should be thrown");
     } catch (Pipeline.PipelineExecutionException exception) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           "java.lang.Exception: Job finished with terminalState FAILED", exception.getMessage());
     }
   }
@@ -100,9 +100,9 @@ public class BeamHelperTest {
         };
     try {
       BeamHelper.waitUntilDone(mockResult, Duration.ofMinutes(1));
-      Assert.fail("A PipelineExecutionException should be thrown");
+      Assertions.fail("A PipelineExecutionException should be thrown");
     } catch (Pipeline.PipelineExecutionException exception) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           "java.lang.Exception: Job cancelled after exceeding timeout PT1M",
           exception.getMessage());
     }
@@ -139,9 +139,9 @@ public class BeamHelperTest {
         };
     try {
       BeamHelper.waitUntilDone(mockResult, Duration.ofMinutes(1));
-      Assert.fail("A PipelineExecutionException should be thrown");
+      Assertions.fail("A PipelineExecutionException should be thrown");
     } catch (Pipeline.PipelineExecutionException exception) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           "java.lang.Exception: Job cancelled after exceeding timeout PT1M",
           exception.getMessage());
     }
@@ -178,9 +178,9 @@ public class BeamHelperTest {
         };
     try {
       BeamHelper.waitUntilDone(mockResult, Duration.ofMinutes(1));
-      Assert.fail("A PipelineExecutionException should be thrown");
+      Assertions.fail("A PipelineExecutionException should be thrown");
     } catch (Pipeline.PipelineExecutionException exception) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           "java.lang.Exception: Job exceeded timeout of PT1M, "
               + "but was not possible to cancel, finished with terminalState RUNNING",
           exception.getMessage());

--- a/dbeam-core/src/test/java/com/spotify/dbeam/jobs/BenchJdbcAvroJobTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/jobs/BenchJdbcAvroJobTest.java
@@ -28,8 +28,8 @@ import com.spotify.dbeam.TestHelper;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.sql.SQLException;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class BenchJdbcAvroJobTest {
 
@@ -37,7 +37,7 @@ public class BenchJdbcAvroJobTest {
       "jdbc:h2:mem:test3;MODE=PostgreSQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1";
   private static Path testDir;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws SQLException, ClassNotFoundException, IOException {
     testDir = TestHelper.createTmpDirPath("jdbc-export-args-test");
     DbTestHelper.createFixtures(CONNECTION_URL);

--- a/dbeam-core/src/test/java/com/spotify/dbeam/jobs/JdbcAvroJobTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/jobs/JdbcAvroJobTest.java
@@ -48,9 +48,9 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class JdbcAvroJobTest {
 
@@ -69,7 +69,7 @@ public class JdbcAvroJobTest {
     return records;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws SQLException, ClassNotFoundException, IOException {
     testDir = TestHelper.createTmpDirPath("jdbc-avro-test-");
     passwordPath = testDir.resolve(".password");
@@ -219,23 +219,26 @@ public class JdbcAvroJobTest {
     assertThat(schemas, CoreMatchers.hasItems(expectedSchemas));
   }
 
-  @Test(expected = FailedValidationException.class)
-  public void shouldFailWithNotEnoughRows() throws Exception {
+  @Test
+  public void shouldFailWithNotEnoughRows() {
     final Path outputPath = testDir.resolve("shouldRunJdbcAvroJob");
 
-    JdbcAvroJob.create(
-            new String[] {
-              "--targetParallelism=1", // no need for more threads when testing
-              "--partition=2025-02-28",
-              "--skipPartitionCheck",
-              "--connectionUrl=" + CONNECTION_URL,
-              "--username=",
-              "--passwordFile=" + passwordPath.toString(),
-              "--table=COFFEES",
-              "--output=" + outputPath,
-              "--minRows=1000"
-            })
-        .runExport();
+    Assertions.assertThrows(
+        FailedValidationException.class,
+        () ->
+            JdbcAvroJob.create(
+                    new String[] {
+                      "--targetParallelism=1", // no need for more threads when testing
+                      "--partition=2025-02-28",
+                      "--skipPartitionCheck",
+                      "--connectionUrl=" + CONNECTION_URL,
+                      "--username=",
+                      "--passwordFile=" + passwordPath.toString(),
+                      "--table=COFFEES",
+                      "--output=" + outputPath,
+                      "--minRows=1000"
+                    })
+                .runExport());
   }
 
   @Test
@@ -255,33 +258,38 @@ public class JdbcAvroJobTest {
             });
     jdbcAvroJob.prepareExport();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         this.getClass().getPackage().getImplementationVersion(),
         jdbcAvroJob.getPipelineOptions().as(DBeamPipelineOptions.class).getDBeamVersion());
   }
 
   @Test
   public void shouldHaveDefaultExitCode() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Integer.valueOf(49), ExceptionHandling.exitCode(new IllegalStateException()));
   }
 
   @Test
   public void shouldExit50OnFailedValidationException() {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Integer.valueOf(50), ExceptionHandling.exitCode(new FailedValidationException("")));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnMissingInput() throws IOException, ClassNotFoundException {
-    JdbcAvroJob.create(PipelineOptionsFactory.create());
+  @Test
+  public void shouldFailOnMissingInput() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> JdbcAvroJob.create(PipelineOptionsFactory.create()));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldFailOnEmptyInput() throws IOException, ClassNotFoundException {
-    final PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
-    pipelineOptions.as(OutputOptions.class).setOutput("");
-    JdbcAvroJob.create(PipelineOptionsFactory.create());
+  @Test
+  public void shouldFailOnEmptyInput() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          final PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
+          pipelineOptions.as(OutputOptions.class).setOutput("");
+          JdbcAvroJob.create(PipelineOptionsFactory.create());
+        });
   }
 
   @Test

--- a/dbeam-core/src/test/java/com/spotify/dbeam/jobs/PsqlAvroJobTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/jobs/PsqlAvroJobTest.java
@@ -21,7 +21,7 @@
 package com.spotify.dbeam.jobs;
 
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PsqlAvroJobTest {
 

--- a/dbeam-core/src/test/java/com/spotify/dbeam/jobs/PsqlReplicationCheckTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/jobs/PsqlReplicationCheckTest.java
@@ -28,8 +28,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.Period;
 import java.util.Optional;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PsqlReplicationCheckTest {
   private static String CONNECTION_URL =
@@ -48,20 +48,22 @@ public class PsqlReplicationCheckTest {
         Optional.empty());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldFailOnInvalidDriver() throws ClassNotFoundException {
     final JdbcExportArgs args =
         createArgs("jdbc:mysql://some_db", QueryBuilderArgs.create("some_table"));
 
-    PsqlReplicationCheck.validateOptions(args);
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> PsqlReplicationCheck.validateOptions(args));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldFailOnMissingPartition() throws ClassNotFoundException {
     final JdbcExportArgs args =
         createArgs("jdbc:postgresql://some_db", QueryBuilderArgs.create("some_table"));
 
-    PsqlReplicationCheck.validateOptions(args);
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> PsqlReplicationCheck.validateOptions(args));
   }
 
   @Test
@@ -82,7 +84,7 @@ public class PsqlReplicationCheckTest {
     final Instant lastReplication = Instant.parse("2027-08-01T00:00:00Z");
     final Period partitionPeriod = Period.ofDays(1);
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         PsqlReplicationCheck.isReplicationDelayed(partition, lastReplication, partitionPeriod));
   }
 
@@ -92,7 +94,7 @@ public class PsqlReplicationCheckTest {
     final Instant lastReplication = Instant.parse("2027-08-02T00:00:00Z");
     final Period partitionPeriod = Period.ofDays(1);
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         PsqlReplicationCheck.isReplicationDelayed(partition, lastReplication, partitionPeriod));
   }
 
@@ -102,7 +104,7 @@ public class PsqlReplicationCheckTest {
     final Instant lastReplication = Instant.parse("2027-07-31T00:00:00Z");
     final Period partitionPeriod = Period.ofDays(1);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         PsqlReplicationCheck.isReplicationDelayed(partition, lastReplication, partitionPeriod));
   }
 
@@ -112,7 +114,7 @@ public class PsqlReplicationCheckTest {
     final Instant lastReplication = Instant.parse("2027-07-30T22:00:00Z");
     final Period partitionPeriod = Period.ofDays(1);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         PsqlReplicationCheck.isReplicationDelayed(partition, lastReplication, partitionPeriod));
   }
 
@@ -122,7 +124,7 @@ public class PsqlReplicationCheckTest {
     final Instant lastReplication = Instant.parse("2027-07-31T23:59:59Z");
     final Period partitionPeriod = Period.ofDays(1);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         PsqlReplicationCheck.isReplicationDelayed(partition, lastReplication, partitionPeriod));
   }
 
@@ -132,7 +134,7 @@ public class PsqlReplicationCheckTest {
     final Instant lastReplication = Instant.parse("2027-07-31T23:59:59Z");
     final Period partitionPeriod = Period.ofMonths(1);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         PsqlReplicationCheck.isReplicationDelayed(partition, lastReplication, partitionPeriod));
   }
 
@@ -142,7 +144,7 @@ public class PsqlReplicationCheckTest {
     final Instant lastReplication = Instant.parse("2027-07-31T00:59:59Z");
     final Duration partitionPeriod = Duration.ofHours(1);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         PsqlReplicationCheck.isReplicationDelayed(partition, lastReplication, partitionPeriod));
   }
 
@@ -152,11 +154,11 @@ public class PsqlReplicationCheckTest {
     final Instant lastReplication = Instant.parse("2027-07-31T00:59:59Z");
     final Duration partitionPeriod = Duration.ofHours(1);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         PsqlReplicationCheck.isReplicationDelayed(partition, lastReplication, partitionPeriod));
   }
 
-  @Test(expected = NotReadyException.class)
+  @Test
   public void shouldRunQueryAndReturnReplicationDelayed() throws Exception {
     final String query =
         "SELECT parsedatetime('2017-02-01 23.58.57 UTC', 'yyyy-MM-dd HH.mm.ss z', 'en', 'UTC')"
@@ -175,9 +177,9 @@ public class PsqlReplicationCheckTest {
 
     final Instant actual = replicationCheck.queryReplication();
 
-    Assert.assertEquals(expectedLastReplication, actual);
-    Assert.assertTrue(replicationCheck.isReplicationDelayed());
-    replicationCheck.checkReplication();
+    Assertions.assertEquals(expectedLastReplication, actual);
+    Assertions.assertTrue(replicationCheck.isReplicationDelayed());
+    Assertions.assertThrows(NotReadyException.class, () -> replicationCheck.checkReplication());
   }
 
   @Test
@@ -199,8 +201,8 @@ public class PsqlReplicationCheckTest {
 
     final Instant actual = replicationCheck.queryReplication();
 
-    Assert.assertEquals(expectedLastReplication, actual);
-    Assert.assertFalse(replicationCheck.isReplicationDelayed());
+    Assertions.assertEquals(expectedLastReplication, actual);
+    Assertions.assertFalse(replicationCheck.isReplicationDelayed());
     replicationCheck.checkReplication();
   }
 }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/options/ArrayHandlingModeTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/options/ArrayHandlingModeTest.java
@@ -20,26 +20,30 @@
 
 package com.spotify.dbeam.options;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ArrayHandlingModeTest {
   @Test
   public void validValuesShouldPass() {
-    Assert.assertEquals(ArrayHandlingMode.Bytes,
-        ArrayHandlingMode.validateValue(ArrayHandlingMode.Bytes));
-    Assert.assertEquals(ArrayHandlingMode.TypedMetaFromFirstRow,
+    Assertions.assertEquals(
+        ArrayHandlingMode.Bytes, ArrayHandlingMode.validateValue(ArrayHandlingMode.Bytes));
+    Assertions.assertEquals(
+        ArrayHandlingMode.TypedMetaFromFirstRow,
         ArrayHandlingMode.validateValue(ArrayHandlingMode.TypedMetaFromFirstRow));
-    Assert.assertEquals(ArrayHandlingMode.TypedMetaPostgres,
+    Assertions.assertEquals(
+        ArrayHandlingMode.TypedMetaPostgres,
         ArrayHandlingMode.validateValue(ArrayHandlingMode.TypedMetaPostgres));
   }
 
   @Test
   public void invalidValueShouldThrow() {
-    RuntimeException thrown = Assert.assertThrows(RuntimeException.class,
-        () -> ArrayHandlingMode.validateValue("invalid"));
-    Assert.assertEquals("Invalid value 'invalid' for array handling mode. Allowed values: "
-        + "[bytes, typed_first_row, typed_postgres]",
+    RuntimeException thrown =
+        Assertions.assertThrows(
+            RuntimeException.class, () -> ArrayHandlingMode.validateValue("invalid"));
+    Assertions.assertEquals(
+        "Invalid value 'invalid' for array handling mode. Allowed values: "
+            + "[bytes, typed_first_row, typed_postgres]",
         thrown.getMessage());
   }
 }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/options/InputAvroSchemaTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/options/InputAvroSchemaTest.java
@@ -37,11 +37,11 @@ import java.util.Optional;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class InputAvroSchemaTest {
 
@@ -49,7 +49,7 @@ public class InputAvroSchemaTest {
   private static Path avroSchemaFilePath;
   private static String avroSchemaFilePathStr;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws IOException {
     final String jsonSchema =
         "{\n"
@@ -104,7 +104,7 @@ public class InputAvroSchemaTest {
     return inputSchema;
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() throws IOException {
     Files.delete(avroSchemaFile.toPath());
   }
@@ -115,17 +115,17 @@ public class InputAvroSchemaTest {
         PipelineOptionsFactory.create().as(JdbcExportPipelineOptions.class);
     options.setAvroSchemaFilePath(avroSchemaFilePathStr);
 
-    Assert.assertEquals(avroSchemaFilePathStr, options.getAvroSchemaFilePath());
+    Assertions.assertEquals(avroSchemaFilePathStr, options.getAvroSchemaFilePath());
 
     final Schema inputSchema = BeamJdbcAvroSchema.parseInputAvroSchemaFile(avroSchemaFilePathStr);
 
-    Assert.assertEquals("Record description", inputSchema.getDoc());
-    Assert.assertEquals("Field1 description", inputSchema.getField("field1").doc());
-    Assert.assertEquals("Field2 description", inputSchema.getField("field2").doc());
+    Assertions.assertEquals("Record description", inputSchema.getDoc());
+    Assertions.assertEquals("Field1 description", inputSchema.getField("field1").doc());
+    Assertions.assertEquals("Field2 description", inputSchema.getField("field2").doc());
   }
 
   @Test
-  @Ignore
+  @Disabled
   public void checkFullPath() {
     // TODO
     // Check provide input string to args and verify final schema
@@ -146,8 +146,8 @@ public class InputAvroSchemaTest {
         PipelineOptionsFactory.create().as(JdbcExportPipelineOptions.class);
     options.setAvroSchemaFilePath(path);
 
-    Assert.assertEquals(path, options.getAvroSchemaFilePath());
-    Assert.assertEquals(
+    Assertions.assertEquals(path, options.getAvroSchemaFilePath());
+    Assertions.assertEquals(
         Optional.empty(), BeamJdbcAvroSchema.parseOptionalInputAvroSchemaFile(path));
   }
 
@@ -158,12 +158,12 @@ public class InputAvroSchemaTest {
         PipelineOptionsFactory.create().as(JdbcExportPipelineOptions.class);
     options.setAvroSchemaFilePath(path);
 
-    Assert.assertEquals(path, options.getAvroSchemaFilePath());
-    Assert.assertEquals(
+    Assertions.assertEquals(path, options.getAvroSchemaFilePath());
+    Assertions.assertEquals(
         Optional.empty(), BeamJdbcAvroSchema.parseOptionalInputAvroSchemaFile(path));
   }
 
-  @Test(expected = SchemaParseException.class)
+  @Test
   public void checkReadAvroSchemaWithInvalidFormat() throws IOException {
     final String invalidJson = "{";
     final File invalidFile = createTestAvroSchemaFile(invalidJson);
@@ -172,19 +172,23 @@ public class InputAvroSchemaTest {
         PipelineOptionsFactory.create().as(JdbcExportPipelineOptions.class);
     options.setAvroSchemaFilePath(path);
 
-    Assert.assertEquals(path, options.getAvroSchemaFilePath());
-    BeamJdbcAvroSchema.parseOptionalInputAvroSchemaFile(path);
+    Assertions.assertEquals(path, options.getAvroSchemaFilePath());
+    Assertions.assertThrows(
+        SchemaParseException.class,
+        () -> BeamJdbcAvroSchema.parseOptionalInputAvroSchemaFile(path));
   }
 
-  @Test(expected = FileNotFoundException.class)
-  public void checkReadAvroSchemaWithNonExistentFile() throws IOException {
+  @Test
+  public void checkReadAvroSchemaWithNonExistentFile() {
     final String path = "non_existent_schema.avsc";
     final JdbcExportPipelineOptions options =
         PipelineOptionsFactory.create().as(JdbcExportPipelineOptions.class);
     options.setAvroSchemaFilePath(path);
 
-    Assert.assertEquals(path, options.getAvroSchemaFilePath());
-    BeamJdbcAvroSchema.parseOptionalInputAvroSchemaFile(path);
+    Assertions.assertEquals(path, options.getAvroSchemaFilePath());
+    Assertions.assertThrows(
+        FileNotFoundException.class,
+        () -> BeamJdbcAvroSchema.parseOptionalInputAvroSchemaFile(path));
   }
 
   @Test
@@ -194,7 +198,7 @@ public class InputAvroSchemaTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--avroSchemaFilePath=/temp/record1.avsc --partition=2027-07-31");
 
-    Assert.assertEquals("/temp/record1.avsc", options.getAvroSchemaFilePath());
+    Assertions.assertEquals("/temp/record1.avsc", options.getAvroSchemaFilePath());
   }
 
   @Test
@@ -204,7 +208,7 @@ public class InputAvroSchemaTest {
             "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
                 + "--partition=2027-07-31");
 
-    Assert.assertNull(options.getAvroSchemaFilePath());
+    Assertions.assertNull(options.getAvroSchemaFilePath());
   }
 
   private QueryBuilderArgs pareOptions(String cmdLineArgs) throws IOException {

--- a/dbeam-core/src/test/java/com/spotify/dbeam/options/JobNameConfigurationTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/options/JobNameConfigurationTest.java
@@ -26,8 +26,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import org.apache.beam.sdk.options.ApplicationNameOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JobNameConfigurationTest {
 
@@ -38,7 +38,7 @@ public class JobNameConfigurationTest {
 
     JobNameConfiguration.configureJobName(pipelineOptions, "some_db", "some_table");
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "JdbcAvroJob", pipelineOptions.as(ApplicationNameOptions.class).getAppName());
     assertThat(pipelineOptions.getJobName(), startsWith("dbeam-somedb-sometable-"));
   }
@@ -50,7 +50,7 @@ public class JobNameConfigurationTest {
 
     JobNameConfiguration.configureJobName(pipelineOptions, "some_db", "some_table");
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "JdbcAvroJob", pipelineOptions.as(ApplicationNameOptions.class).getAppName());
     assertThat(pipelineOptions.getJobName(), startsWith("dbeam-somedb-sometable-"));
   }
@@ -62,10 +62,10 @@ public class JobNameConfigurationTest {
 
     JobNameConfiguration.configureJobName(pipelineOptions, "some_db", null);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "JdbcAvroJob", pipelineOptions.as(ApplicationNameOptions.class).getAppName());
 
     assertThat(pipelineOptions.getJobName(), startsWith("dbeam-somedb-"));
-    Assert.assertEquals(3, pipelineOptions.getJobName().split("-").length);
+    Assertions.assertEquals(3, pipelineOptions.getJobName().split("-").length);
   }
 }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/options/PasswordReaderTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/options/PasswordReaderTest.java
@@ -32,23 +32,23 @@ import java.nio.file.StandardOpenOption;
 import java.util.Optional;
 import org.apache.beam.sdk.extensions.gcp.auth.NoopCredentialFactory;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class PasswordReaderTest {
 
   private static File passwordFile;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws IOException {
     passwordFile = File.createTempFile("pattern", ".suffix");
     passwordFile.deleteOnExit();
     Files.write(passwordFile.toPath(), "something_encrypted".getBytes(), StandardOpenOption.CREATE);
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() throws IOException {
     Files.delete(passwordFile.toPath());
   }
@@ -83,6 +83,6 @@ public class PasswordReaderTest {
 
     final Optional<String> actualPassword = passwordReader.readPassword(options);
 
-    Assert.assertEquals(Optional.of("something_decrypted"), actualPassword);
+    Assertions.assertEquals(Optional.of("something_decrypted"), actualPassword);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -653,7 +653,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.7</version>
+            <version>3.2.8</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <junit.version>4.13.2</junit.version>
     <mysql.version>8.4.0</mysql.version>
     <mariadb.version>3.5.3</mariadb.version>
-    <postgresql.version>42.7.4</postgresql.version>
+    <postgresql.version>42.7.7</postgresql.version>
     <socket-factory.version>1.18.0</socket-factory.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -633,7 +633,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.23.0</version>
+            <version>10.26.1</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.9.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <commons-codec.version>1.17.1</commons-codec.version>
     <commons-compress.version>1.26.2</commons-compress.version>
     <errorprone.version>2.31.0</errorprone.version>
-    <guava.version>33.1.0-jre</guava.version>
+    <guava.version>33.5.0-jre</guava.version>
     <hamcrest.version>2.1</hamcrest.version>
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.14</httpcore.version>
@@ -258,18 +258,6 @@
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-bigtable-admin-v2</artifactId>
         <version>2.73.1</version>
-      </dependency>
-      <!-- resolve j2objc-annotations convergence: guava uses 3.0.0, libraries-bom brings 3.1 -->
-      <dependency>
-        <groupId>com.google.j2objc</groupId>
-        <artifactId>j2objc-annotations</artifactId>
-        <version>3.1</version>
-      </dependency>
-      <!-- resolve failureaccess convergence: guava 33.x uses 1.0.2, transitives bring 1.0.3 -->
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>failureaccess</artifactId>
-        <version>1.0.3</version>
       </dependency>
       <!-- overrides to resolve dependency conflicts - end-->
       <!-- overrides with vulnerability fixes - start-->

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <hamcrest.version>2.1</hamcrest.version>
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.14</httpcore.version>
-    <jackson.version>2.15.4</jackson.version>
+    <jackson.version>2.18.2</jackson.version>
     <joda-time.version>2.14.0</joda-time.version>
     <netty.version>4.1.124.Final</netty.version>
     <slf4j.version>2.0.16</slf4j.version>
@@ -237,12 +237,6 @@
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-contrib-grpc-metrics</artifactId>
         <version>${opencensus.version}</version>
-      </dependency>
-      <!-- resolve jackson-dataformat-xml convergence: google-cloud-storage brings 2.18.2 -->
-      <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-xml</artifactId>
-        <version>2.18.2</version>
       </dependency>
       <!-- resolve google-cloud-bigtable convergence: beam io brings 2.73.1 vs libraries-bom 2.73.0 -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <beam.version>2.65.0</beam.version>
     <!-- versions from beam -->
     <auto-value.version>1.9</auto-value.version>
-    <avro.version>1.11.4</avro.version>
+    <avro.version>1.11.5</avro.version>
     <checker-qual.version>3.42.0</checker-qual.version>
     <commons-codec.version>1.17.1</commons-codec.version>
     <commons-compress.version>1.26.2</commons-compress.version>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <bouncycastle.version>1.78.1</bouncycastle.version>
     <junit.version>4.13.2</junit.version>
     <mysql.version>8.4.0</mysql.version>
-    <mariadb.version>3.5.3</mariadb.version>
+    <mariadb.version>3.5.8</mariadb.version>
     <postgresql.version>42.7.8</postgresql.version>
     <socket-factory.version>1.18.0</socket-factory.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -532,7 +532,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.2</version>
           <executions>
             <execution>
               <id>enforce</id>

--- a/pom.xml
+++ b/pom.xml
@@ -106,8 +106,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- apache beam BOM -->
-    <!-- https://github.com/apache/beam/blob/release-2.72/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy#L588 -->
-    <beam.version>2.72.0</beam.version>
+    <!-- https://github.com/apache/beam/blob/release-2.73/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy#L588 -->
+    <beam.version>2.73.0</beam.version>
     <!-- versions from beam -->
     <auto-value.version>1.9</auto-value.version>
     <avro.version>1.11.5</avro.version>
@@ -128,8 +128,8 @@
 
     <!-- GCP BOM -->
     <!-- https://github.com/googleapis/java-cloud-bom/releases -->
-    <!-- https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/26.76.0/index.html -->
-    <google-cloud-libraries-bom.version>26.76.0</google-cloud-libraries-bom.version>
+    <!-- https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/26.79.0/index.html -->
+    <google-cloud-libraries-bom.version>26.79.0</google-cloud-libraries-bom.version>
     <!-- versions from GCP bom -->
     <opencensus.version>0.31.1</opencensus.version>
 
@@ -237,27 +237,6 @@
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-contrib-grpc-metrics</artifactId>
         <version>${opencensus.version}</version>
-      </dependency>
-      <!-- resolve google-cloud-bigtable convergence: beam io brings 2.73.1 vs libraries-bom 2.73.0 -->
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-bigtable</artifactId>
-        <version>2.73.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
-        <version>2.73.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>proto-google-cloud-bigtable-v2</artifactId>
-        <version>2.73.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>proto-google-cloud-bigtable-admin-v2</artifactId>
-        <version>2.73.1</version>
       </dependency>
       <!-- overrides to resolve dependency conflicts - end-->
       <!-- overrides with vulnerability fixes - start-->

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
 
     <!-- other deps -->
     <bouncycastle.version>1.84</bouncycastle.version>
-    <junit.version>4.13.2</junit.version>
+    <junit-jupiter.version>5.11.4</junit-jupiter.version>
     <mysql.version>8.4.0</mysql.version>
     <mariadb.version>3.5.8</mariadb.version>
     <postgresql.version>42.7.8</postgresql.version>
@@ -400,10 +400,11 @@
 
       <!-- Test Deps -->
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
-        <scope>test</scope>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit-jupiter.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
@@ -420,6 +421,12 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
+        <version>5.20.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
         <version>5.20.0</version>
         <scope>test</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <!-- https://github.com/apache/beam/blob/release-2.74/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy#L588 -->
     <beam.version>2.74.0</beam.version>
     <!-- versions from beam -->
-    <auto-value.version>1.11.0</auto-value.version>
+    <auto-value.version>1.11.1</auto-value.version>
     <avro.version>1.12.0</avro.version>
     <checker-qual.version>3.42.0</checker-qual.version>
     <commons-codec.version>1.17.1</commons-codec.version>
@@ -135,10 +135,10 @@
 
     <!-- other deps -->
     <bouncycastle.version>1.84</bouncycastle.version>
-    <junit-jupiter.version>5.11.4</junit-jupiter.version>
+    <junit-jupiter.version>5.14.4</junit-jupiter.version>
     <mysql.version>8.4.0</mysql.version>
     <mariadb.version>3.5.8</mariadb.version>
-    <postgresql.version>42.7.8</postgresql.version>
+    <postgresql.version>42.7.11</postgresql.version>
     <socket-factory.version>1.25.0</socket-factory.version>
   </properties>
 
@@ -432,19 +432,19 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>5.20.0</version>
+        <version>5.23.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
-        <version>5.20.0</version>
+        <version>5.23.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>2.3.232</version>
+        <version>2.4.240</version>
         <scope>test</scope>
       </dependency>
     </dependencies>
@@ -476,7 +476,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.14.1</version>
+          <version>3.15.0</version>
           <configuration>
             <!-- JDK 23+ disabled implicit annotation processing (JEP 472).
                  Declare processors explicitly so javac runs them. -->
@@ -499,7 +499,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.3.1</version>
           <configuration>
             <tagNameFormat>v@{project.version}</tagNameFormat>
             <allowTimestampedSnapshots>true</allowTimestampedSnapshots>
@@ -512,30 +512,30 @@
             <dependency>
               <groupId>org.apache.maven.scm</groupId>
               <artifactId>maven-scm-provider-gitexe</artifactId>
-              <version>2.1.0</version>
+              <version>2.2.1</version>
             </dependency>
             <dependency>
               <groupId>org.apache.maven.scm</groupId>
               <artifactId>maven-scm-api</artifactId>
-              <version>2.1.0</version>
+              <version>2.2.1</version>
             </dependency>
           </dependencies>
         </plugin>
 
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.21.0</version>
+          <version>3.22.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.4.2</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.4.0</version>
           <executions>
             <execution>
               <id>attach-sources</id>
@@ -548,11 +548,11 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.9.0</version>
+          <version>3.10.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.5.5</version>
+          <version>3.5.6</version>
           <configuration>
             <reuseForks>true</reuseForks>
             <!--<forkCount>2</forkCount>-->
@@ -561,7 +561,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.6.2</version>
+          <version>3.6.3</version>
           <executions>
             <execution>
               <id>enforce</id>
@@ -727,7 +727,7 @@
           <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.8.0</version>
+            <version>0.10.0</version>
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>ossrh</publishingServerId>
@@ -808,7 +808,7 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.13</version>
+            <version>0.8.14</version>
             <configuration>
               <!--Configure to work on codecov-->
               <!--https://github.com/codecov/example-java/blob/master/pom.xml-->

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <opencensus.version>0.31.1</opencensus.version>
 
     <!-- other deps -->
-    <bouncycastle.version>1.78.1</bouncycastle.version>
+    <bouncycastle.version>1.84</bouncycastle.version>
     <junit.version>4.13.2</junit.version>
     <mysql.version>8.4.0</mysql.version>
     <mariadb.version>3.5.8</mariadb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -732,7 +732,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.6.0</version>
+            <version>3.6.2</version>
             <executions>
               <execution>
                 <id>bundle-and-repackage</id>

--- a/pom.xml
+++ b/pom.xml
@@ -675,7 +675,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.11.2</version>
+            <version>3.12.0</version>
             <configuration>
               <source>8</source>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.5.3</version>
+          <version>3.5.5</version>
           <configuration>
             <reuseForks>true</reuseForks>
             <!--<forkCount>2</forkCount>-->

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <mysql.version>8.4.0</mysql.version>
     <mariadb.version>3.5.8</mariadb.version>
     <postgresql.version>42.7.8</postgresql.version>
-    <socket-factory.version>1.18.0</socket-factory.version>
+    <socket-factory.version>1.25.0</socket-factory.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -106,11 +106,11 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- apache beam BOM -->
-    <!-- https://github.com/apache/beam/blob/release-2.73/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy#L588 -->
-    <beam.version>2.73.0</beam.version>
+    <!-- https://github.com/apache/beam/blob/release-2.74/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy#L588 -->
+    <beam.version>2.74.0</beam.version>
     <!-- versions from beam -->
     <auto-value.version>1.11.0</auto-value.version>
-    <avro.version>1.11.5</avro.version>
+    <avro.version>1.12.0</avro.version>
     <checker-qual.version>3.42.0</checker-qual.version>
     <commons-codec.version>1.17.1</commons-codec.version>
     <commons-compress.version>1.26.2</commons-compress.version>
@@ -119,17 +119,17 @@
     <hamcrest.version>2.1</hamcrest.version>
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.14</httpcore.version>
-    <jackson.version>2.18.2</jackson.version>
+    <jackson.version>2.18.3</jackson.version>
     <joda-time.version>2.14.0</joda-time.version>
-    <netty.version>4.1.124.Final</netty.version>
+    <netty.version>4.1.130.Final</netty.version>
     <slf4j.version>2.0.16</slf4j.version>
     <threetenbp.version>1.6.8</threetenbp.version>
     <zstd-jni.version>1.5.7-7</zstd-jni.version>
 
     <!-- GCP BOM -->
     <!-- https://github.com/googleapis/java-cloud-bom/releases -->
-    <!-- https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/26.79.0/index.html -->
-    <google-cloud-libraries-bom.version>26.79.0</google-cloud-libraries-bom.version>
+    <!-- https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/26.80.0/index.html -->
+    <google-cloud-libraries-bom.version>26.80.0</google-cloud-libraries-bom.version>
     <!-- versions from GCP bom -->
     <opencensus.version>0.31.1</opencensus.version>
 
@@ -231,6 +231,17 @@
         <groupId>org.threeten</groupId>
         <artifactId>threetenbp</artifactId>
         <version>${threetenbp.version}</version>
+      </dependency>
+      <!-- from bigdataoss (requires higher than libraries-bom) -->
+      <dependency>
+        <groupId>com.google.api-client</groupId>
+        <artifactId>google-api-client</artifactId>
+        <version>2.9.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api-client</groupId>
+        <artifactId>google-api-client-gson</artifactId>
+        <version>2.9.0</version>
       </dependency>
       <!-- from libraries-bom -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
       <dependency>
         <groupId>com.google.apis</groupId>
         <artifactId>google-api-services-cloudkms</artifactId>
-        <version>v1-rev20240314-2.0.0</version>
+        <version>v1-rev20260319-2.0.0</version>
       </dependency>
 
       <!-- Runners -->

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <netty.version>4.1.124.Final</netty.version>
     <slf4j.version>2.0.16</slf4j.version>
     <threetenbp.version>1.6.8</threetenbp.version>
-    <zstd-jni.version>1.5.6-3</zstd-jni.version>
+    <zstd-jni.version>1.5.7-7</zstd-jni.version>
 
     <!-- GCP BOM -->
     <!-- https://github.com/googleapis/java-cloud-bom/releases -->

--- a/pom.xml
+++ b/pom.xml
@@ -458,7 +458,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.13.0</version>
+          <version>3.14.1</version>
           <executions>
             <execution>
               <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -106,30 +106,30 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- apache beam BOM -->
-    <!-- https://github.com/apache/beam/blob/release-2.65/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy#L588 -->
-    <beam.version>2.65.0</beam.version>
+    <!-- https://github.com/apache/beam/blob/release-2.72/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy#L588 -->
+    <beam.version>2.72.0</beam.version>
     <!-- versions from beam -->
     <auto-value.version>1.9</auto-value.version>
     <avro.version>1.11.5</avro.version>
     <checker-qual.version>3.42.0</checker-qual.version>
     <commons-codec.version>1.17.1</commons-codec.version>
     <commons-compress.version>1.26.2</commons-compress.version>
-    <errorprone.version>2.10.0</errorprone.version>
+    <errorprone.version>2.31.0</errorprone.version>
     <guava.version>33.1.0-jre</guava.version>
     <hamcrest.version>2.1</hamcrest.version>
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.14</httpcore.version>
     <jackson.version>2.15.4</jackson.version>
-    <joda-time.version>2.10.14</joda-time.version>
-    <netty.version>4.1.121.Final</netty.version>
-    <slf4j.version>1.7.30</slf4j.version>
+    <joda-time.version>2.14.0</joda-time.version>
+    <netty.version>4.1.124.Final</netty.version>
+    <slf4j.version>2.0.16</slf4j.version>
     <threetenbp.version>1.6.8</threetenbp.version>
     <zstd-jni.version>1.5.6-3</zstd-jni.version>
 
     <!-- GCP BOM -->
     <!-- https://github.com/googleapis/java-cloud-bom/releases -->
-    <!-- https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/26.45.0/index.html -->
-    <google-cloud-libraries-bom.version>26.57.0</google-cloud-libraries-bom.version>
+    <!-- https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/26.76.0/index.html -->
+    <google-cloud-libraries-bom.version>26.76.0</google-cloud-libraries-bom.version>
     <!-- versions from GCP bom -->
     <opencensus.version>0.31.1</opencensus.version>
 
@@ -237,6 +237,45 @@
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-contrib-grpc-metrics</artifactId>
         <version>${opencensus.version}</version>
+      </dependency>
+      <!-- resolve jackson-dataformat-xml convergence: google-cloud-storage brings 2.18.2 -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-xml</artifactId>
+        <version>2.18.2</version>
+      </dependency>
+      <!-- resolve google-cloud-bigtable convergence: beam io brings 2.73.1 vs libraries-bom 2.73.0 -->
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable</artifactId>
+        <version>2.73.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
+        <version>2.73.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-cloud-bigtable-v2</artifactId>
+        <version>2.73.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-cloud-bigtable-admin-v2</artifactId>
+        <version>2.73.1</version>
+      </dependency>
+      <!-- resolve j2objc-annotations convergence: guava uses 3.0.0, libraries-bom brings 3.1 -->
+      <dependency>
+        <groupId>com.google.j2objc</groupId>
+        <artifactId>j2objc-annotations</artifactId>
+        <version>3.1</version>
+      </dependency>
+      <!-- resolve failureaccess convergence: guava 33.x uses 1.0.2, transitives bring 1.0.3 -->
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>failureaccess</artifactId>
+        <version>1.0.3</version>
       </dependency>
       <!-- overrides to resolve dependency conflicts - end-->
       <!-- overrides with vulnerability fixes - start-->

--- a/pom.xml
+++ b/pom.xml
@@ -420,7 +420,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>5.17.0</version>
+        <version>5.20.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
   </distributionManagement>
 
   <properties>
-    <maven.compiler.release>8</maven.compiler.release>
+    <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -109,7 +109,7 @@
     <!-- https://github.com/apache/beam/blob/release-2.73/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy#L588 -->
     <beam.version>2.73.0</beam.version>
     <!-- versions from beam -->
-    <auto-value.version>1.9</auto-value.version>
+    <auto-value.version>1.11.0</auto-value.version>
     <avro.version>1.11.5</avro.version>
     <checker-qual.version>3.42.0</checker-qual.version>
     <commons-codec.version>1.17.1</commons-codec.version>
@@ -459,6 +459,17 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.14.1</version>
+          <configuration>
+            <!-- JDK 23+ disabled implicit annotation processing (JEP 472).
+                 Declare processors explicitly so javac runs them. -->
+            <annotationProcessorPaths>
+              <path>
+                <groupId>com.google.auto.value</groupId>
+                <artifactId>auto-value</artifactId>
+                <version>${auto-value.version}</version>
+              </path>
+            </annotationProcessorPaths>
+          </configuration>
           <executions>
             <execution>
               <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <junit.version>4.13.2</junit.version>
     <mysql.version>8.4.0</mysql.version>
     <mariadb.version>3.5.3</mariadb.version>
-    <postgresql.version>42.7.7</postgresql.version>
+    <postgresql.version>42.7.8</postgresql.version>
     <socket-factory.version>1.18.0</socket-factory.version>
   </properties>
 


### PR DESCRIPTION
## Summary

- Dependency updates. It has been 10 months since https://github.com/spotify/dbeam/pull/987.
- Migrate tests from JUnit 4 to JUnit 5.
- Support building with Java 25.

**Key upgrade:** Apache Beam SDK 2.65.0 → 2.74.0. Beam 2.65.0 was [deprecated on May 12, 2026](https://docs.cloud.google.com/dataflow/docs/support/sdk-version-support-status). Beam 2.74.0 is the latest stable release (June 2, 2026), supported until June 2027.

### Dependency updates

- **Apache Beam SDK**: 2.65.0 → 2.74.0
- **Avro**: 1.11.4 → 1.12.0
- **Jackson**: 2.15.4 → 2.18.3
- **Guava**: 33.1.0-jre → 33.5.0-jre
- **google-cloud-libraries-bom**: 26.57.0 → 26.80.0
- **google-api-client**: override to 2.9.0 (resolve bigdataoss conflict with libraries-bom)
- **Netty**: 4.1.121.Final → 4.1.130.Final
- **SLF4J**: 1.7.30 → 2.0.16
- **Error Prone**: 2.10.0 → 2.31.0
- **Joda-Time**: 2.10.14 → 2.14.0
- **PostgreSQL JDBC**: 42.7.4 → 42.7.11 (fixes [CVE-2025-49146](https://nvd.nist.gov/vuln/detail/CVE-2025-49146))
- **MariaDB JDBC**: 3.5.3 → 3.5.8
- **Cloud SQL socket factory**: 1.18.0 → 1.25.0
- **google-api-services-cloudkms**: v1-rev20240314 → v1-rev20260319
- **zstd-jni**: 1.5.6-3 → 1.5.7-7
- **BouncyCastle**: 1.78.1 → 1.84
- **Auto-Value**: 1.9 → 1.11.1

### Test framework

- **JUnit**: 4.13.2 → JUnit Jupiter 5.14.4
- **Mockito**: 5.17.0 → 5.23.0
- **H2**: 2.3.232 → 2.4.240
- Migrated all test classes from JUnit 4 (`@org.junit.Test`, `Assert.*`) to JUnit 5 (`@org.junit.jupiter.api.Test`, `Assertions.*`)
- Fixed Avro 1.12.0 test breakage: primitive arrays now use `PrimitivesArrays$IntArray` instead of `GenericData$Array`

### Maven plugin updates

- maven-compiler-plugin → 3.15.0
- maven-release-plugin → 3.3.1
- maven-scm: 2.1.0 → 2.2.1
- maven-site-plugin → 3.22.0
- maven-jar-plugin → 3.5.0
- maven-source-plugin → 3.4.0
- maven-project-info-reports-plugin → 3.10.0
- maven-surefire-plugin: 3.5.3 → 3.5.6
- maven-enforcer-plugin: 3.5.0 → 3.6.3
- maven-shade-plugin: 3.6.0 → 3.6.2
- maven-javadoc-plugin: 3.11.2 → 3.12.0
- maven-gpg-plugin: 3.2.7 → 3.2.8
- maven-checkstyle-plugin → 3.6.0
- build-helper-maven-plugin: 3.6.0 → 3.6.1
- central-publishing-maven-plugin: 0.8.0 → 0.10.0
- jacoco-maven-plugin: 0.8.13 → 0.8.14
- Checkstyle: 10.23.0 → 10.26.1

### Other

- Support Java 25 build (explicit annotation processor paths for JEP 472)
- CI: use Java 21 for e2e tests and deploy

## Test plan

- [x] `mvn verify` passes locally
- [x] CI passes with Java 25