### PR TITLE
ci: declare minimum permissions on CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,11 @@ on:
   schedule:
     - cron: '0 12 * * 5'
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Currently `.github/workflows/codeql-analysis.yml` carries no `permissions` block, so the analyze run inherits whatever the repo or org default `GITHUB_TOKEN` scope is set to. This PR declares the three scopes the workflow actually needs at the top level: `actions: read`, `contents: read`, and `security-events: write` for the SARIF upload step. It is the same shape the current GitHub CodeQL starter template recommends.

The reason to nail this down explicitly even when the inherited default may already be reasonable is the supply-chain threat surfaced by CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise): a tampered third-party action can read `GITHUB_TOKEN` out of the runner and the blast radius is whatever scope the token carries. Pinning the workflow scope caps the runtime authority of every action that runs inside it, gives drift protection if the org default ever widens, and is what OpenSSF Scorecard's Token-Permissions check actually credits.

YAML validated locally with `yaml.safe_load`.
