### PR TITLE
Add --useTimestampMicros flag for microsecond precision without external schema

### DIFF
--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcAvroArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcAvroArgs.java
@@ -92,17 +92,6 @@ public abstract class JdbcAvroArgs implements Serializable {
       final String avroCodec,
       final List<String> preCommand,
       final String arrayMode,
-      final Boolean nullableArrayItems) {
-    return create(jdbcConnectionArgs, fetchSize, avroCodec, preCommand,
-        arrayMode, nullableArrayItems, false);
-  }
-
-  public static JdbcAvroArgs create(
-      final JdbcConnectionArgs jdbcConnectionArgs,
-      final int fetchSize,
-      final String avroCodec,
-      final List<String> preCommand,
-      final String arrayMode,
       final Boolean nullableArrayItems,
       final Boolean useTimestampMicros) {
     Preconditions.checkArgument(

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcAvroArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcAvroArgs.java
@@ -49,6 +49,8 @@ public abstract class JdbcAvroArgs implements Serializable {
 
   public abstract Boolean nullableArrayItems();
 
+  public abstract Boolean useTimestampMicros();
+
   abstract Builder builder();
 
   public CodecFactory getCodecFactory() {
@@ -79,6 +81,8 @@ public abstract class JdbcAvroArgs implements Serializable {
 
     abstract Builder setNullableArrayItems(Boolean nullableArrayItems);
 
+    abstract Builder setUseTimestampMicros(Boolean useTimestampMicros);
+
     abstract JdbcAvroArgs build();
   }
 
@@ -89,6 +93,18 @@ public abstract class JdbcAvroArgs implements Serializable {
       final List<String> preCommand,
       final String arrayMode,
       final Boolean nullableArrayItems) {
+    return create(jdbcConnectionArgs, fetchSize, avroCodec, preCommand,
+        arrayMode, nullableArrayItems, false);
+  }
+
+  public static JdbcAvroArgs create(
+      final JdbcConnectionArgs jdbcConnectionArgs,
+      final int fetchSize,
+      final String avroCodec,
+      final List<String> preCommand,
+      final String arrayMode,
+      final Boolean nullableArrayItems,
+      final Boolean useTimestampMicros) {
     Preconditions.checkArgument(
         avroCodec.matches("snappy|deflate[1-9]|zstandard[1-9]"),
         "Avro codec should be snappy or deflate1, .., deflate9");
@@ -99,12 +115,13 @@ public abstract class JdbcAvroArgs implements Serializable {
         .setPreCommand(preCommand)
         .setArrayMode(arrayMode)
         .setNullableArrayItems(nullableArrayItems)
+        .setUseTimestampMicros(useTimestampMicros)
         .build();
   }
 
   public static JdbcAvroArgs create(final JdbcConnectionArgs jdbcConnectionArgs) {
     return create(jdbcConnectionArgs, 10000, "deflate6", Collections.emptyList(),
-        "typed_first_row", false);
+        "typed_first_row", false, false);
   }
 
   public interface StatementPreparator extends Serializable {

--- a/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/args/JdbcExportArgs.java
@@ -45,6 +45,8 @@ public abstract class JdbcExportArgs implements Serializable {
 
   public abstract Boolean useAvroLogicalTypes();
 
+  public abstract Boolean useTimestampMicros();
+
   public abstract Duration exportTimeout();
 
   public abstract Optional<Schema> inputAvroSchema();
@@ -64,6 +66,8 @@ public abstract class JdbcExportArgs implements Serializable {
 
     abstract Builder setUseAvroLogicalTypes(Boolean useAvroLogicalTypes);
 
+    abstract Builder setUseTimestampMicros(Boolean useTimestampMicros);
+
     abstract Builder setExportTimeout(Duration exportTimeout);
 
     abstract Builder setInputAvroSchema(Optional<Schema> inputAvroSchema);
@@ -81,6 +85,7 @@ public abstract class JdbcExportArgs implements Serializable {
         Optional.empty(),
         Optional.empty(),
         false,
+        false,
         Duration.ofDays(7),
         Optional.empty());
   }
@@ -92,6 +97,7 @@ public abstract class JdbcExportArgs implements Serializable {
       final Optional<String> avroSchemaName,
       final Optional<String> avroDoc,
       final Boolean useAvroLogicalTypes,
+      final Boolean useTimestampMicros,
       final Duration exportTimeout,
       final Optional<Schema> inputAvroSchema) {
     return new AutoValue_JdbcExportArgs.Builder()
@@ -101,6 +107,7 @@ public abstract class JdbcExportArgs implements Serializable {
         .setAvroSchemaName(avroSchemaName)
         .setAvroDoc(avroDoc)
         .setUseAvroLogicalTypes(useAvroLogicalTypes)
+        .setUseTimestampMicros(useTimestampMicros)
         .setExportTimeout(exportTimeout)
         .setInputAvroSchema(inputAvroSchema)
         .build();

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/BeamJdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/BeamJdbcAvroSchema.java
@@ -91,6 +91,7 @@ public class BeamJdbcAvroSchema {
         args.avroSchemaName(),
         avroDoc,
         args.useAvroLogicalTypes(),
+        args.useTimestampMicros(),
         args.jdbcAvroOptions().arrayMode(),
         args.jdbcAvroOptions().nullableArrayItems());
   }

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroIO.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroIO.java
@@ -206,7 +206,8 @@ public class JdbcAvroIO {
       try (ResultSet resultSet = executeQuery(query)) {
         metering.startWriteMeter();
         final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(resultSet,
-            this.jdbcAvroArgs.arrayMode(), this.jdbcAvroArgs.nullableArrayItems());
+            this.jdbcAvroArgs.arrayMode(), this.jdbcAvroArgs.nullableArrayItems(),
+            this.jdbcAvroArgs.useTimestampMicros());
         while (resultSet.next()) {
           dataFileWriter.appendEncoded(converter.convertResultSetIntoAvroBytes());
           this.metering.incrementRecordCount();

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroRecord.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroRecord.java
@@ -53,7 +53,8 @@ public class JdbcAvroRecord {
 
   static SqlFunction<ResultSet, Object> computeMapping(final ResultSetMetaData meta,
                                                        final int column,
-                                                       final String arrayMode)
+                                                       final String arrayMode,
+                                                       final boolean useTimestampMicros)
       throws SQLException {
     switch (meta.getColumnType(column)) {
       case VARCHAR:
@@ -77,6 +78,19 @@ public class JdbcAvroRecord {
       case DATE:
       case TIME:
       case TIME_WITH_TIMEZONE:
+        if (useTimestampMicros) {
+          return resultSet -> {
+            final Timestamp ts = resultSet.getTimestamp(column, CALENDAR);
+            if (ts != null) {
+              final long millis = ts.getTime();
+              final int nanos = ts.getNanos();
+              final long microsFromNanos = (nanos / 1000) % 1000;
+              return millis * 1000 + microsFromNanos;
+            } else {
+              return null;
+            }
+          };
+        }
         return resultSet -> {
           final Timestamp timestamp = resultSet.getTimestamp(column, CALENDAR);
           if (timestamp != null) {

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroRecordConverter.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroRecordConverter.java
@@ -51,10 +51,11 @@ public class JdbcAvroRecordConverter {
 
   public static JdbcAvroRecordConverter create(final ResultSet resultSet,
                                                final String arrayMode,
-                                               final boolean nullableArrayItems)
+                                               final boolean nullableArrayItems,
+                                               final boolean useTimestampMicros)
       throws SQLException {
     return new JdbcAvroRecordConverter(
-        computeAllMappings(resultSet, arrayMode),
+        computeAllMappings(resultSet, arrayMode, useTimestampMicros),
         resultSet.getMetaData().getColumnCount(),
         resultSet,
         nullableArrayItems);
@@ -62,7 +63,7 @@ public class JdbcAvroRecordConverter {
 
   @SuppressWarnings("unchecked")
   static JdbcAvroRecord.SqlFunction<ResultSet, Object>[] computeAllMappings(
-      final ResultSet resultSet, final String arrayMode)
+      final ResultSet resultSet, final String arrayMode, final boolean useTimestampMicros)
       throws SQLException {
     final ResultSetMetaData meta = resultSet.getMetaData();
     final int columnCount = meta.getColumnCount();
@@ -72,7 +73,7 @@ public class JdbcAvroRecordConverter {
             new JdbcAvroRecord.SqlFunction<?, ?>[columnCount + 1];
 
     for (int i = 1; i <= columnCount; i++) {
-      mappings[i] = JdbcAvroRecord.computeMapping(meta, i, arrayMode);
+      mappings[i] = JdbcAvroRecord.computeMapping(meta, i, arrayMode, useTimestampMicros);
     }
     return mappings;
   }

--- a/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/avro/JdbcAvroSchema.java
@@ -77,6 +77,7 @@ public class JdbcAvroSchema {
       final Optional<String> schemaName,
       final String avroDoc,
       final boolean useLogicalTypes,
+      final boolean useTimestampMicros,
       final String arrayMode,
       final boolean nullableArrayItems)
       throws SQLException {
@@ -94,10 +95,12 @@ public class JdbcAvroSchema {
               schemaName,
               avroDoc,
               useLogicalTypes,
+              useTimestampMicros,
               arrayMode,
               nullableArrayItems);
-      LOGGER.info("Schema created successfully. useLogicalTypes={}, arrayMode={}, "
-                  + "Generated schema: {}", useLogicalTypes, arrayMode, schema.toString());
+      LOGGER.info("Schema created successfully. useLogicalTypes={}, useTimestampMicros={}, "
+                  + "arrayMode={}, Generated schema: {}",
+                  useLogicalTypes, useTimestampMicros, arrayMode, schema.toString());
       return schema;
     }
   }
@@ -109,6 +112,7 @@ public class JdbcAvroSchema {
       final Optional<String> maybeSchemaName,
       final String avroDoc,
       final boolean useLogicalTypes,
+      final boolean useTimestampMicros,
       final String arrayMode,
       final boolean nullableArrayItems)
       throws SQLException {
@@ -124,7 +128,8 @@ public class JdbcAvroSchema {
             .prop("tableName", tableName)
             .prop("connectionUrl", connectionUrl)
             .fields();
-    return createAvroFields(resultSet, builder, useLogicalTypes, arrayMode, nullableArrayItems)
+    return createAvroFields(
+            resultSet, builder, useLogicalTypes, useTimestampMicros, arrayMode, nullableArrayItems)
         .endRecord();
   }
 
@@ -144,6 +149,7 @@ public class JdbcAvroSchema {
       final ResultSet resultSet,
       final SchemaBuilder.FieldAssembler<Schema> builder,
       final boolean useLogicalTypes,
+      final boolean useTimestampMicros,
       final String arrayMode,
       final boolean nullableArrayItems)
       throws SQLException {
@@ -194,6 +200,7 @@ public class JdbcAvroSchema {
               columnClassName,
               columnTypeName,
               useLogicalTypes,
+              useTimestampMicros,
               arrayMode,
               nullableArrayItems,
               fieldSchemaBuilder);
@@ -223,6 +230,7 @@ public class JdbcAvroSchema {
       final String columnClassName,
       final String columnTypeName,
       final boolean useLogicalTypes,
+      final boolean useTimestampMicros,
       final String arrayMode,
       final boolean nullableArrayItems,
       final SchemaBuilder.BaseTypeBuilder<SchemaBuilder.UnionAccumulator<
@@ -243,7 +251,9 @@ public class JdbcAvroSchema {
       case TIME:
       case TIME_WITH_TIMEZONE:
         if (useLogicalTypes) {
-          return field.longBuilder().prop("logicalType", "timestamp-millis").endLong();
+          final String logicalType =
+              useTimestampMicros ? "timestamp-micros" : "timestamp-millis";
+          return field.longBuilder().prop("logicalType", logicalType).endLong();
         } else {
           return field.longType();
         }
@@ -287,6 +297,7 @@ public class JdbcAvroSchema {
             columnClassName,
             arrayInstance.getBaseTypeName(),
             useLogicalTypes,
+            useTimestampMicros,
             arrayMode,
             nullableArrayItems,
             buildArrayItems(nullableArrayItems, field));

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
@@ -70,7 +70,8 @@ public class JdbcExportArgsFactory {
             exportOptions.getAvroCodec(),
             Optional.ofNullable(exportOptions.getPreCommand()).orElse(Collections.emptyList()),
             ArrayHandlingMode.validateValue(exportOptions.getArrayMode()),
-            exportOptions.isNullableArrayItems()
+            exportOptions.isNullableArrayItems(),
+            exportOptions.isUseTimestampMicros()
             );
 
     return JdbcExportArgs.create(
@@ -80,6 +81,7 @@ public class JdbcExportArgsFactory {
         Optional.ofNullable(exportOptions.getAvroSchemaName()),
         Optional.ofNullable(exportOptions.getAvroDoc()),
         exportOptions.isUseAvroLogicalTypes(),
+        exportOptions.isUseTimestampMicros(),
         Duration.parse(exportOptions.getExportTimeout()),
         BeamJdbcAvroSchema.parseOptionalInputAvroSchemaFile(exportOptions.getAvroSchemaFilePath()));
   }

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportArgsFactory.java
@@ -61,6 +61,9 @@ public class JdbcExportArgsFactory {
   public static JdbcExportArgs fromPipelineOptions(final PipelineOptions options)
       throws ClassNotFoundException, IOException {
     final JdbcExportPipelineOptions exportOptions = options.as(JdbcExportPipelineOptions.class);
+    checkArgument(
+        !exportOptions.isUseTimestampMicros() || exportOptions.isUseAvroLogicalTypes(),
+        "--useTimestampMicros requires --useAvroLogicalTypes");
     final JdbcAvroArgs jdbcAvroArgs =
         JdbcAvroArgs.create(
             JdbcConnectionArgs.create(exportOptions.getConnectionUrl())

--- a/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
+++ b/dbeam-core/src/main/java/com/spotify/dbeam/options/JdbcExportPipelineOptions.java
@@ -87,6 +87,15 @@ public interface JdbcExportPipelineOptions extends DBeamPipelineOptions {
 
   void setUseAvroLogicalTypes(Boolean value);
 
+  @Default.Boolean(false)
+  @Description(
+      "When set with --useAvroLogicalTypes, timestamp columns use timestamp-micros "
+          + "(microsecond precision) instead of the default timestamp-millis. "
+          + "PostgreSQL stores TIMESTAMPTZ at microsecond precision; this flag preserves it.")
+  Boolean isUseTimestampMicros();
+
+  void setUseTimestampMicros(Boolean value);
+
   @Default.String("typed_first_row")
   @Description("Configures how arrays are treated: bytes, typed_first_row, typed_postgres.")
   String getArrayMode();

--- a/dbeam-core/src/test/java/com/spotify/dbeam/args/JdbcExportOptionsTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/args/JdbcExportOptionsTest.java
@@ -238,6 +238,28 @@ public class JdbcExportOptionsTest {
   }
 
   @Test
+  public void shouldRejectTimestampMicrosWithoutAvroLogicalTypes() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            optionsFromArgs(
+                "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
+                    + "--password=secret --useTimestampMicros=true"));
+  }
+
+  @Test
+  public void shouldConfigureTimestampMicrosWithAvroLogicalTypes()
+      throws IOException, ClassNotFoundException {
+    final JdbcExportArgs options =
+        optionsFromArgs(
+            "--connectionUrl=jdbc:postgresql://some_db --table=some_table "
+                + "--password=secret --useTimestampMicros=true --useAvroLogicalTypes=true");
+
+    Assertions.assertTrue(options.useTimestampMicros());
+    Assertions.assertTrue(options.useAvroLogicalTypes());
+  }
+
+  @Test
   public void shouldConfigureAvroDoc() throws IOException, ClassNotFoundException {
     final JdbcExportArgs options =
         optionsFromArgs(

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroRecordTest.java
@@ -83,7 +83,7 @@ public class JdbcAvroRecordTest {
             "dbeam_generated",
             Optional.empty(),
             "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test",
-            false, ArrayHandlingMode.TypedMetaFromFirstRow, false);
+            false, false, ArrayHandlingMode.TypedMetaFromFirstRow, false);
 
     Assertions.assertNotNull(actual);
     Assertions.assertEquals("dbeam_generated", actual.getNamespace());
@@ -162,7 +162,7 @@ public class JdbcAvroRecordTest {
             "dbeam_generated",
             Optional.empty(),
             "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test",
-            true, ArrayHandlingMode.TypedMetaFromFirstRow, false);
+            true, false, ArrayHandlingMode.TypedMetaFromFirstRow, false);
 
     Assertions.assertEquals(fieldCount, actual.getFields().size());
     Assertions.assertEquals(
@@ -179,7 +179,7 @@ public class JdbcAvroRecordTest {
             "dbeam_generated",
             Optional.of("CustomSchemaName"),
             "Generate schema from JDBC ResultSet from COFFEES jdbc:h2:mem:test",
-            false, ArrayHandlingMode.TypedMetaFromFirstRow, false);
+            false, false, ArrayHandlingMode.TypedMetaFromFirstRow, false);
 
     Assertions.assertEquals("CustomSchemaName", actual.getName());
   }
@@ -197,8 +197,9 @@ public class JdbcAvroRecordTest {
     final Schema schema =
         JdbcAvroSchema.createAvroSchema(
             rs, "dbeam_generated", "connection", Optional.empty(), "doc",
-            false, arrayMode, false);
-    final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(rs, arrayMode, false);
+            false, false, arrayMode, false);
+    final JdbcAvroRecordConverter converter =
+        JdbcAvroRecordConverter.create(rs, arrayMode, false, false);
     final DataFileWriter<GenericRecord> dataFileWriter =
         new DataFileWriter<>(new GenericDatumWriter<>(schema));
     final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -262,7 +263,8 @@ public class JdbcAvroRecordTest {
     when(metadata.getColumnClassName(columnNum)).thenReturn("java.lang.Long");
 
     final JdbcAvroRecord.SqlFunction<ResultSet, Object> mapping =
-        JdbcAvroRecord.computeMapping(metadata, columnNum, ArrayHandlingMode.TypedMetaFromFirstRow);
+        JdbcAvroRecord.computeMapping(
+            metadata, columnNum, ArrayHandlingMode.TypedMetaFromFirstRow, false);
 
     final ResultSet resultSet = Mockito.mock(ResultSet.class);
     when(resultSet.getLong(columnNum)).thenReturn(valueUnderTest);

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
@@ -78,7 +78,7 @@ public class JdbcAvroSchemaTest {
   public void shouldConvertDateSqlTypeWithAvroLogicalType() throws SQLException {
     final ResultSet resultSet = buildMockResultSet(Types.DATE);
 
-    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, true);
+    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, true, false);
 
     Assertions.assertEquals(Schema.Type.LONG, fieldSchema.getType());
     Assertions.assertEquals("timestamp-millis", fieldSchema.getProp("logicalType"));
@@ -88,7 +88,7 @@ public class JdbcAvroSchemaTest {
   public void shouldConvertDateSqlTypeWithoutAvroLogicalType() throws SQLException {
     final ResultSet resultSet = buildMockResultSet(Types.DATE);
 
-    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
+    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false, false);
 
     Assertions.assertEquals(Schema.Type.LONG, fieldSchema.getType());
     Assertions.assertNull(fieldSchema.getProp("logicalType"));
@@ -98,7 +98,7 @@ public class JdbcAvroSchemaTest {
   public void shouldConvertBigIntSqlTypeToLong() throws SQLException {
     final ResultSet resultSet = buildMockResultSet(Types.BIGINT);
 
-    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
+    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false, false);
 
     Assertions.assertEquals(Schema.Type.LONG, fieldSchema.getType());
   }
@@ -107,7 +107,7 @@ public class JdbcAvroSchemaTest {
   public void shouldConvertBitSqlTypeWithNoPrecisionToBoolean() throws SQLException {
     final ResultSet resultSet = buildMockResultSet(Types.BIT);
 
-    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
+    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false, false);
 
     Assertions.assertEquals(Schema.Type.BOOLEAN, fieldSchema.getType());
   }
@@ -117,7 +117,7 @@ public class JdbcAvroSchemaTest {
     final ResultSet resultSet = buildMockResultSet(Types.BIT);
     when(resultSet.getMetaData().getPrecision(COLUMN_NUM)).thenReturn(2);
 
-    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
+    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false, false);
 
     Assertions.assertEquals(Schema.Type.BYTES, fieldSchema.getType());
   }
@@ -127,25 +127,29 @@ public class JdbcAvroSchemaTest {
     final ResultSet resultSet = buildMockResultSet(Types.STRUCT);
     RuntimeException thrown =
         Assertions.assertThrows(
-            RuntimeException.class, () -> createAvroSchemaForSingleField(resultSet, false));
+            RuntimeException.class,
+            () -> createAvroSchemaForSingleField(resultSet, false, false));
     Assertions.assertEquals("STRUCT type is not supported", thrown.getMessage());
 
     final ResultSet resultSet2 = buildMockResultSet(Types.REF);
     RuntimeException thrown2 =
         Assertions.assertThrows(
-            RuntimeException.class, () -> createAvroSchemaForSingleField(resultSet2, false));
+            RuntimeException.class,
+            () -> createAvroSchemaForSingleField(resultSet2, false, false));
     Assertions.assertEquals("REF and REF_CURSOR type are not supported", thrown2.getMessage());
 
     final ResultSet resultSet3 = buildMockResultSet(Types.REF_CURSOR);
     RuntimeException thrown3 =
         Assertions.assertThrows(
-            RuntimeException.class, () -> createAvroSchemaForSingleField(resultSet3, false));
+            RuntimeException.class,
+            () -> createAvroSchemaForSingleField(resultSet3, false, false));
     Assertions.assertEquals("REF and REF_CURSOR type are not supported", thrown3.getMessage());
 
     final ResultSet resultSet4 = buildMockResultSet(Types.DATALINK);
     RuntimeException thrown4 =
         Assertions.assertThrows(
-            RuntimeException.class, () -> createAvroSchemaForSingleField(resultSet4, false));
+            RuntimeException.class,
+            () -> createAvroSchemaForSingleField(resultSet4, false, false));
     Assertions.assertEquals("DATALINK type is not supported", thrown4.getMessage());
   }
 
@@ -154,7 +158,7 @@ public class JdbcAvroSchemaTest {
     final ResultSet resultSet = buildMockResultSet(Types.INTEGER);
     when(resultSet.getMetaData().getColumnClassName(COLUMN_NUM)).thenReturn("java.lang.Long");
 
-    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
+    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false, false);
 
     Assertions.assertEquals(Schema.Type.LONG, fieldSchema.getType());
   }
@@ -163,7 +167,7 @@ public class JdbcAvroSchemaTest {
   public void shouldConvertIntegerSqlTypeToInteger() throws SQLException {
     final ResultSet resultSet = buildMockResultSet(Types.INTEGER);
 
-    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
+    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false, false);
 
     Assertions.assertEquals(Schema.Type.INT, fieldSchema.getType());
   }
@@ -172,7 +176,7 @@ public class JdbcAvroSchemaTest {
   public void shouldDefaultConversionToStringType() throws SQLException {
     final ResultSet resultSet = buildMockResultSet(Types.SQLXML);
 
-    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
+    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false, false);
 
     Assertions.assertEquals(Schema.Type.STRING, fieldSchema.getType());
   }
@@ -180,7 +184,7 @@ public class JdbcAvroSchemaTest {
   @Test
   public void shouldConvertUuidSqlTypeWithAvroLogicalType() throws SQLException {
     final ResultSet resultSet = buildMockResultSet(Types.OTHER, "uuid");
-    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, true);
+    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, true, false);
 
     Assertions.assertEquals(Schema.Type.STRING, fieldSchema.getType());
     Assertions.assertEquals("uuid", fieldSchema.getProp("logicalType"));
@@ -189,15 +193,10 @@ public class JdbcAvroSchemaTest {
   @Test
   public void shouldConvertUuidSqlTypeWithoutAvroLogicalType() throws SQLException {
     final ResultSet resultSet = buildMockResultSet(Types.OTHER, "uuid");
-    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false);
+    final Schema fieldSchema = createAvroSchemaForSingleField(resultSet, false, false);
 
     Assertions.assertEquals(Schema.Type.STRING, fieldSchema.getType());
     Assertions.assertNull(fieldSchema.getProp("logicalType"));
-  }
-
-  private Schema createAvroSchemaForSingleField(
-      final ResultSet resultSet, final boolean useLogicalTypes) throws SQLException {
-    return createAvroSchemaForSingleField(resultSet, useLogicalTypes, false);
   }
 
   private Schema createAvroSchemaForSingleField(

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/JdbcAvroSchemaTest.java
@@ -197,10 +197,16 @@ public class JdbcAvroSchemaTest {
 
   private Schema createAvroSchemaForSingleField(
       final ResultSet resultSet, final boolean useLogicalTypes) throws SQLException {
+    return createAvroSchemaForSingleField(resultSet, useLogicalTypes, false);
+  }
+
+  private Schema createAvroSchemaForSingleField(
+      final ResultSet resultSet, final boolean useLogicalTypes,
+      final boolean useTimestampMicros) throws SQLException {
     Schema avroSchema =
         JdbcAvroSchema.createAvroSchema(
             resultSet, "namespace1", "url1", Optional.empty(), "doc1", useLogicalTypes,
-            ArrayHandlingMode.TypedMetaFromFirstRow, false);
+            useTimestampMicros, ArrayHandlingMode.TypedMetaFromFirstRow, false);
 
     return avroSchema.getField("column1").schema().getTypes().get(COLUMN_NUM);
   }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/avro/PostgresJdbcAvroTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/avro/PostgresJdbcAvroTest.java
@@ -31,6 +31,7 @@ import java.nio.ByteBuffer;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
@@ -110,9 +111,9 @@ public class PostgresJdbcAvroTest {
 
     String arrayMode = ArrayHandlingMode.TypedMetaFromFirstRow;
     final Schema schema = JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
-        Optional.empty(), "doc", true, arrayMode, false);
+        Optional.empty(), "doc", true, false, arrayMode, false);
     final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(
-        resultSet, arrayMode, false);
+        resultSet, arrayMode, false, false);
 
     GenericRecord actualRecord = bytesToGenericRecords(schema,
         converter.convertResultSetIntoAvroBytes())[0];
@@ -144,9 +145,9 @@ public class PostgresJdbcAvroTest {
 
     String arrayMode = ArrayHandlingMode.TypedMetaFromFirstRow;
     final Schema schema = JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
-        Optional.empty(), "doc", true, arrayMode, false);
+        Optional.empty(), "doc", true, false, arrayMode, false);
     final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(resultSet, arrayMode,
-        false);
+        false, false);
 
     GenericRecord actualRecord =
         bytesToGenericRecords(schema, converter.convertResultSetIntoAvroBytes())[0];
@@ -177,6 +178,7 @@ public class PostgresJdbcAvroTest {
                 Optional.empty(),
                 "doc",
                 true,
+                false,
                 ArrayHandlingMode.TypedMetaFromFirstRow,
                 false));
   }
@@ -195,9 +197,9 @@ public class PostgresJdbcAvroTest {
     String arrayMode = ArrayHandlingMode.Bytes;
 
     final Schema schema = JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
-        Optional.empty(), "doc", true, arrayMode, false);
+        Optional.empty(), "doc", true, false, arrayMode, false);
     final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(resultSet, arrayMode,
-        false);
+        false, false);
 
     GenericRecord actualRecord =
         bytesToGenericRecords(schema, converter.convertResultSetIntoAvroBytes())[0];
@@ -231,9 +233,9 @@ public class PostgresJdbcAvroTest {
     String arrayMode = ArrayHandlingMode.TypedMetaPostgres;
 
     final Schema schema = JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
-        Optional.empty(), "doc", true, arrayMode, false);
+        Optional.empty(), "doc", true, false, arrayMode, false);
     final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(resultSet, arrayMode,
-        false);
+        false, false);
     GenericRecord[] actualRecords = bytesToGenericRecords(schema,
         converter.convertResultSetIntoAvroBytes(), converter.convertResultSetIntoAvroBytes());
 
@@ -272,9 +274,9 @@ public class PostgresJdbcAvroTest {
     boolean nullableArrayItems = true;
 
     final Schema schema = JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
-        Optional.empty(), "doc", true, arrayMode, nullableArrayItems);
+        Optional.empty(), "doc", true, false, arrayMode, nullableArrayItems);
     final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(resultSet, arrayMode,
-        nullableArrayItems);
+        nullableArrayItems, false);
     GenericRecord actualRecord = bytesToGenericRecords(schema,
         converter.convertResultSetIntoAvroBytes(), converter.convertResultSetIntoAvroBytes())[0];
 
@@ -305,7 +307,7 @@ public class PostgresJdbcAvroTest {
     boolean nullableArrayItems = false;
 
     final JdbcAvroRecordConverter converter =
-        JdbcAvroRecordConverter.create(resultSet, arrayMode, nullableArrayItems);
+        JdbcAvroRecordConverter.create(resultSet, arrayMode, nullableArrayItems, false);
     RuntimeException thrown =
         Assertions.assertThrows(
             RuntimeException.class, () -> converter.convertResultSetIntoAvroBytes());
@@ -329,7 +331,7 @@ public class PostgresJdbcAvroTest {
     boolean nullableArrayItems = false;
 
     final JdbcAvroRecordConverter converter =
-        JdbcAvroRecordConverter.create(resultSet, arrayMode, nullableArrayItems);
+        JdbcAvroRecordConverter.create(resultSet, arrayMode, nullableArrayItems, false);
     RuntimeException thrown =
         Assertions.assertThrows(
             RuntimeException.class, () -> converter.convertResultSetIntoAvroBytes());
@@ -363,6 +365,7 @@ public class PostgresJdbcAvroTest {
                     Optional.empty(),
                     "doc",
                     true,
+                    false,
                     arrayMode,
                     nullableArrayItems));
     Assertions.assertEquals(
@@ -395,10 +398,83 @@ public class PostgresJdbcAvroTest {
                     Optional.empty(),
                     "doc",
                     true,
+                    false,
                     arrayMode,
                     nullableArrayItems));
     Assertions.assertEquals(
         "columnName=array_field_text Postgres type 'not_supported' is not supported",
         thrown.getMessage());
+  }
+
+  @Test
+  public void shouldUseTimestampMicrosWhenFlagEnabled() throws SQLException, IOException {
+    final ResultSetMetaData meta = Mockito.mock(ResultSetMetaData.class);
+    when(meta.getColumnCount()).thenReturn(1);
+    TestHelper.mockResultSetMeta(meta, 1, Types.TIMESTAMP, "created_at",
+        "java.sql.Timestamp", "timestamptz");
+
+    final ResultSet resultSet = Mockito.mock(ResultSet.class);
+    when(resultSet.getMetaData()).thenReturn(meta);
+    when(resultSet.isFirst()).thenReturn(true);
+
+    // 2026-09-04T12:00:00.123456Z — 123ms + 456µs
+    final Timestamp ts = Timestamp.valueOf("2026-09-04 12:00:00.123456");
+    when(resultSet.getTimestamp(Mockito.eq(1), Mockito.any())).thenReturn(ts);
+    when(resultSet.wasNull()).thenReturn(false);
+
+    String arrayMode = ArrayHandlingMode.TypedMetaFromFirstRow;
+
+    // Schema should use timestamp-micros
+    final Schema schema = JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
+        Optional.empty(), "doc", true, true, arrayMode, false);
+    Assertions.assertEquals("timestamp-micros",
+        schema.getField("created_at").schema().getTypes().get(1).getProp("logicalType"));
+
+    // Converter should produce microsecond values
+    final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(
+        resultSet, arrayMode, false, true);
+    GenericRecord[] records = bytesToGenericRecords(schema,
+        converter.convertResultSetIntoAvroBytes());
+    final long microsValue = (Long) records[0].get("created_at");
+
+    // Millis would be ts.getTime() = N; micros should be N*1000 + sub-ms component
+    final long expectedMicros = ts.getTime() * 1000 + (ts.getNanos() / 1000) % 1000;
+    Assertions.assertEquals(expectedMicros, microsValue);
+    // The sub-millisecond component (456µs) should be preserved
+    Assertions.assertEquals(456, microsValue % 1000);
+  }
+
+  @Test
+  public void shouldUseTimestampMillisWhenFlagDisabled() throws SQLException, IOException {
+    final ResultSetMetaData meta = Mockito.mock(ResultSetMetaData.class);
+    when(meta.getColumnCount()).thenReturn(1);
+    TestHelper.mockResultSetMeta(meta, 1, Types.TIMESTAMP, "created_at",
+        "java.sql.Timestamp", "timestamptz");
+
+    final ResultSet resultSet = Mockito.mock(ResultSet.class);
+    when(resultSet.getMetaData()).thenReturn(meta);
+    when(resultSet.isFirst()).thenReturn(true);
+
+    final Timestamp ts = Timestamp.valueOf("2026-09-04 12:00:00.123456");
+    when(resultSet.getTimestamp(Mockito.eq(1), Mockito.any())).thenReturn(ts);
+    when(resultSet.wasNull()).thenReturn(false);
+
+    String arrayMode = ArrayHandlingMode.TypedMetaFromFirstRow;
+
+    // Schema should use timestamp-millis when flag is false
+    final Schema schema = JdbcAvroSchema.createAvroSchema(resultSet, "ns", "conn_url",
+        Optional.empty(), "doc", true, false, arrayMode, false);
+    Assertions.assertEquals("timestamp-millis",
+        schema.getField("created_at").schema().getTypes().get(1).getProp("logicalType"));
+
+    // Converter should produce millisecond values
+    final JdbcAvroRecordConverter converter = JdbcAvroRecordConverter.create(
+        resultSet, arrayMode, false, false);
+    GenericRecord[] records = bytesToGenericRecords(schema,
+        converter.convertResultSetIntoAvroBytes());
+    final long millisValue = (Long) records[0].get("created_at");
+
+    // Should be plain millis — sub-ms precision lost
+    Assertions.assertEquals(ts.getTime(), millisValue);
   }
 }

--- a/dbeam-core/src/test/java/com/spotify/dbeam/jobs/PsqlReplicationCheckTest.java
+++ b/dbeam-core/src/test/java/com/spotify/dbeam/jobs/PsqlReplicationCheckTest.java
@@ -44,6 +44,7 @@ public class PsqlReplicationCheckTest {
         Optional.empty(),
         Optional.empty(),
         false,
+        false,
         Duration.ZERO,
         Optional.empty());
   }

--- a/e2e/VerifyTimestampMicros.java
+++ b/e2e/VerifyTimestampMicros.java
@@ -1,0 +1,71 @@
+/*-
+ * -\-\-
+ * DBeam Core
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+
+public final class VerifyTimestampMicros {
+
+  private VerifyTimestampMicros() {}
+
+  public static void main(String[] args) throws Exception {
+    if (args.length != 1) {
+      throw new IllegalArgumentException("Expected one Avro file path");
+    }
+
+    final List<Long> createdAtValues = new ArrayList<>();
+    String logicalType = null;
+    try (DataFileReader<GenericRecord> reader =
+        new DataFileReader<>(new File(args[0]), new GenericDatumReader<>())) {
+      Schema.Field createdAtField = reader.getSchema().getField("created_at");
+      for (Schema typeSchema : createdAtField.schema().getTypes()) {
+        String lt = typeSchema.getProp("logicalType");
+        if (lt != null) {
+          logicalType = lt;
+        }
+      }
+      while (reader.hasNext()) {
+        createdAtValues.add((Long) reader.next().get("created_at"));
+      }
+    }
+
+    if (!"timestamp-micros".equals(logicalType)) {
+      throw new AssertionError(
+          "Expected logicalType=timestamp-micros in auto-generated schema, got: " + logicalType);
+    }
+    if (createdAtValues.size() != 3) {
+      throw new AssertionError("Expected 3 rows, found " + createdAtValues.size());
+    }
+    if (createdAtValues.get(0).equals(createdAtValues.get(1))) {
+      throw new AssertionError(
+          "row1 and row2 have identical created_at values: " + createdAtValues);
+    }
+    if (createdAtValues.get(0) % 1000 == 0 || createdAtValues.get(1) % 1000 == 0) {
+      throw new AssertionError(
+          "created_at values lost microsecond precision: " + createdAtValues);
+    }
+
+  }
+}

--- a/e2e/ddl.sql
+++ b/e2e/ddl.sql
@@ -41,3 +41,20 @@ FROM
 ;
 ANALYZE demo_table;
 EXPLAIN ANALYZE SELECT * FROM demo_table;
+
+-- Table for timestamp-micros precision testing
+DROP TABLE IF EXISTS timestamp_micros_test;
+CREATE TABLE timestamp_micros_test (
+  id serial PRIMARY KEY,
+  name text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+INSERT INTO timestamp_micros_test (name, created_at, updated_at)
+VALUES
+  ('row1', '2026-08-20 19:06:01.879123+00',
+          '2026-08-20 19:06:02.123456+00'),
+  ('row2', '2026-08-20 19:06:01.879456+00',
+          '2026-08-20 19:06:02.654321+00'),
+  ('row3', '2026-08-20 19:06:01.879000+00',
+          '2026-08-20 19:06:02.000000+00');

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 shopt -s expand_aliases
-source ~/.bashrc
+if [[ -f ~/.bashrc ]]; then
+  source ~/.bashrc
+fi
 
 # fail on error
 set -o errexit
@@ -99,6 +101,62 @@ runDBeamDockerCon() {
   avro-tools tojson --head=5 $OUTPUT_FILE
 }
 
+run_docker_dbeam_jdbc() {
+  time docker run --interactive --rm \
+    --net="$DOCKER_NETWORK" \
+    --mount="type=bind,source=$PROJECT_PATH/dbeam-core/target,target=/dbeam" \
+    --mount="type=bind,source=$SCRIPT_PATH,target=$SCRIPT_PATH" \
+    --memory=1G \
+    --entrypoint=/usr/bin/java \
+    "$JAVA_DOCKER_IMAGE" \
+    "${JAVA_OPTS[@]}" \
+    -cp /dbeam/dbeam-core-shaded.jar \
+    com.spotify.dbeam.jobs.JdbcAvroJob "$@"
+}
+
+runTimestampMicrosTest() {
+  echo "=== timestamp-micros e2e test ==="
+  local OUTPUT
+  OUTPUT="$SCRIPT_PATH/results/timestamp_micros/"
+  rm -rf "$OUTPUT"
+  set -o xtrace
+  run_docker_dbeam_jdbc \
+    --skipPartitionCheck \
+    --runner=DirectRunner \
+    "--connectionUrl=jdbc:postgresql://dbeam-postgres:5432/$PSQL_DB" \
+    "--username=$PSQL_USER" \
+    "--password=$PSQL_PASSWORD" \
+    "--table=timestamp_micros_test" \
+    "--output=$OUTPUT" \
+    "--avroSchemaNamespace=dbeam_generated" \
+    --useAvroLogicalTypes \
+    --useTimestampMicros \
+    --avroCodec=deflate1
+  set +o xtrace
+
+  local AVRO_FILE
+  AVRO_FILE=$(find "$OUTPUT" -name '*.avro' | head -n 1)
+  if [[ -z "$AVRO_FILE" ]]; then
+    echo "FAIL: no avro output file found"
+    return 1
+  fi
+
+  echo "--- verifying microsecond precision ---"
+  java \
+    --class-path "$PROJECT_PATH/dbeam-core/target/dbeam-core-shaded.jar" \
+    "$SCRIPT_PATH/VerifyTimestampMicros.java" \
+    "$AVRO_FILE"
+  echo "PASS: timestamp values retain microsecond precision"
+}
+
+timestampMicros() {
+  dockerClean
+  trap dockerClean EXIT
+  pack
+  startPostgres
+  runTimestampMicrosTest
+}
+
 runSuite() {
   table=demo_table
   BINARY_TRANSFER='false' runDBeamDockerCon --executions=3 --avroCodec=deflate1
@@ -106,6 +164,7 @@ runSuite() {
   BINARY_TRANSFER='false' runDBeamDockerCon --executions=3 --avroCodec=deflate1 --queryParallelism=5 --splitColumn=row_number
   BINARY_TRANSFER='false' runDBeamDockerCon --executions=3 --avroCodec=deflate1 --arrayMode=bytes
   BINARY_TRANSFER='false' runDBeamDockerCon --executions=3 --avroCodec=deflate1 --arrayMode=typed_postgres
+  runTimestampMicrosTest
 }
 
 light() {


### PR DESCRIPTION
## Why

PostgreSQL stores `TIMESTAMPTZ` values at microsecond precision, but dbeam currently converts them through `Timestamp.getTime()`, truncating the sub-millisecond digits.

## What

This adds `--useTimestampMicros`. When it is combined with `--useAvroLogicalTypes`, dbeam:

- emits `timestamp-micros` in the schema generated from the JDBC `ResultSet`; and
- converts JDBC timestamps using `Timestamp.getNanos()` so the microsecond component is preserved.

Schema and data now come from the same `ResultSet`, so no external schema file is needed and field order remains aligned.

Without `--useTimestampMicros`, behavior is unchanged.

## e2e results
before & after
<img width="706" height="100" alt="Screenshot 2026-09-04 at 10 16 41 PM" src="https://github.com/user-attachments/assets/a7949056-c710-4929-84b6-462fa95aa122" />

<img width="415" height="61" alt="Screenshot 2026-09-04 at 10 09 44 PM" src="https://github.com/user-attachments/assets/36a86fe5-456a-4aed-b591-98cd7625c071" />
